### PR TITLE
Meta constructor for `BlockDiagLinearOperator` to fix its `matmul` in special case

### DIFF
--- a/linear_operator/operators/block_diag_linear_operator.py
+++ b/linear_operator/operators/block_diag_linear_operator.py
@@ -18,26 +18,20 @@ class _MetaBlockDiagLinearOperator(ABCMeta):
     def __call__(cls, base_linear_op: LinearOperator, block_dim=-3):
         from .diag_linear_operator import DiagLinearOperator
 
-        if cls is BlockDiagLinearOperator and isinstance(
-            base_linear_op, DiagLinearOperator
-        ):
+        if cls is BlockDiagLinearOperator and isinstance(base_linear_op, DiagLinearOperator):
             if block_dim != -3:
                 raise NotImplementedError(
                     "Passing a base_linear_op of type DiagLinearOperator to the constructor of "
                     f"BlockDiagLinearOperator with block_dim = {block_dim} != -3 is not supported."
                 )
             else:
-                diag = base_linear_op._diag.flatten(
-                    -2, -1
-                )  # flatten last two dimensions of diag
+                diag = base_linear_op._diag.flatten(-2, -1)  # flatten last two dimensions of diag
                 return DiagLinearOperator(diag)
         else:
             return type.__call__(cls, base_linear_op, block_dim)
 
 
-class BlockDiagLinearOperator(
-    BlockLinearOperator, metaclass=_MetaBlockDiagLinearOperator
-):
+class BlockDiagLinearOperator(BlockLinearOperator, metaclass=_MetaBlockDiagLinearOperator):
     """
     Represents a lazy tensor that is the block diagonal of square matrices.
     The :attr:`block_dim` attribute specifies which dimension of the base LinearOperator
@@ -83,12 +77,8 @@ class BlockDiagLinearOperator(
 
     def _get_indices(self, row_index, col_index, *batch_indices):
         # Figure out what block the row/column indices belong to
-        row_index_block = torch.div(
-            row_index, self.base_linear_op.size(-2), rounding_mode="floor"
-        )
-        col_index_block = torch.div(
-            col_index, self.base_linear_op.size(-1), rounding_mode="floor"
-        )
+        row_index_block = torch.div(row_index, self.base_linear_op.size(-2), rounding_mode="floor")
+        col_index_block = torch.div(col_index, self.base_linear_op.size(-1), rounding_mode="floor")
 
         # Find the row/col index within each block
         row_index = row_index.fmod(self.base_linear_op.size(-2))
@@ -96,9 +86,7 @@ class BlockDiagLinearOperator(
 
         # If the row/column blocks do not agree, then we have off diagonal elements
         # These elements should be zeroed out
-        res = self.base_linear_op._get_indices(
-            row_index, col_index, *batch_indices, row_index_block
-        )
+        res = self.base_linear_op._get_indices(row_index, col_index, *batch_indices, row_index_block)
         res = res * torch.eq(row_index_block, col_index_block).type_as(res)
         return res
 
@@ -113,9 +101,7 @@ class BlockDiagLinearOperator(
         return self.__class__(self.base_linear_op._root_decomposition())
 
     def _root_inv_decomposition(self, initial_vectors=None):
-        return self.__class__(
-            self.base_linear_op._root_inv_decomposition(initial_vectors)
-        )
+        return self.__class__(self.base_linear_op._root_inv_decomposition(initial_vectors))
 
     def _size(self):
         shape = list(self.base_linear_op.shape)
@@ -144,9 +130,7 @@ class BlockDiagLinearOperator(
                 inv_quad_res = inv_quad_res.view(*self.base_linear_op.batch_shape)
                 inv_quad_res = inv_quad_res.sum(-1)
             else:
-                inv_quad_res = inv_quad_res.view(
-                    *self.base_linear_op.batch_shape, inv_quad_res.size(-1)
-                )
+                inv_quad_res = inv_quad_res.view(*self.base_linear_op.batch_shape, inv_quad_res.size(-1))
                 inv_quad_res = inv_quad_res.sum(-2)
         if logdet_res is not None and logdet_res.numel():
             logdet_res = logdet_res.view(*logdet_res.shape).sum(-1)
@@ -162,9 +146,7 @@ class BlockDiagLinearOperator(
         V = self.__class__(V)
         return U, S, V
 
-    def _symeig(
-        self, eigenvectors: bool = False
-    ) -> Tuple[Tensor, Optional[LinearOperator]]:
+    def _symeig(self, eigenvectors: bool = False) -> Tuple[Tensor, Optional[LinearOperator]]:
         evals, evecs = self.base_linear_op._symeig(eigenvectors=eigenvectors)
         # Doesn't make much sense to sort here, o/w we lose the structure
         evals = evals.reshape(*evals.shape[:-2], evals.shape[-2:].numel())

--- a/test/operators/test_block_diag_linear_operator.py
+++ b/test/operators/test_block_diag_linear_operator.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 
-from linear_operator.operators import BlockDiagLinearOperator, DenseLinearOperator
+from linear_operator.operators import BlockDiagLinearOperator, DiagLinearOperator, DenseLinearOperator
 from linear_operator.test.linear_operator_test_case import LinearOperatorTestCase
 
 
@@ -66,6 +66,36 @@ class TestBlockDiagLinearOperatorMultiBatch(LinearOperatorTestCase, unittest.Tes
                 for k in range(5):
                     actual[i, k, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = blocks[i, k, j]
         return actual
+
+class TestBlockDiagLinearOperatorMetaClass(unittest.TestCase):
+    def test_metaclass_constructor(self):
+        k, n = 3, 5 # number of blocks, block size
+        b1, b2 = 2, 3 # batch dimensions
+        base_operators = [torch.randn(k, n), torch.randn(b1, b2, k, n)]
+
+        for base_op in base_operators: # repeats tests for both batched and non-batched tensors
+            base_diag = DiagLinearOperator(base_op)
+            linear_op = BlockDiagLinearOperator(base_diag)
+
+            # checks that metaclass constructor returns a diagonal operator
+            # if a DiagLinearOperator is passed to BlockDiagLinearOperator
+            self.assertEqual(type(linear_op), DiagLinearOperator)
+
+            # matrix-vector-multiplication test
+            diag_values = base_op.flatten(start_dim = -2) # operator of non-blocked diagonal values
+            x = torch.randn(diag_values.shape)
+            self.assertTrue(torch.equal(diag_values * x, (linear_op @ x.unsqueeze(-1)).squeeze(-1)))
+
+            # checks that the representation is numerically accurate
+            dense_operator = linear_op.to_dense()
+            truth_operator = torch.diag_embed(diag_values) # creates batch of diagonal operators
+            self.assertTrue(torch.equal(dense_operator, truth_operator))
+
+            with self.assertRaises(NotImplementedError):
+                # beside the dimensions not working out here, this should never
+                # be allowed as long as there is no special case for it, because
+                # matmuls with the resulting object will fail
+                BlockDiagLinearOperator(base_diag, block_dim=-2)
 
 
 if __name__ == "__main__":

--- a/test/operators/test_block_diag_linear_operator.py
+++ b/test/operators/test_block_diag_linear_operator.py
@@ -4,7 +4,11 @@ import unittest
 
 import torch
 
-from linear_operator.operators import BlockDiagLinearOperator, DiagLinearOperator, DenseLinearOperator
+from linear_operator.operators import (
+    BlockDiagLinearOperator,
+    DiagLinearOperator,
+    DenseLinearOperator,
+)
 from linear_operator.test.linear_operator_test_case import LinearOperatorTestCase
 
 
@@ -64,38 +68,53 @@ class TestBlockDiagLinearOperatorMultiBatch(LinearOperatorTestCase, unittest.Tes
         for i in range(2):
             for j in range(6):
                 for k in range(5):
-                    actual[i, k, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = blocks[i, k, j]
+                    actual[i, k, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = blocks[
+                        i, k, j
+                    ]
         return actual
+
 
 class TestBlockDiagLinearOperatorMetaClass(unittest.TestCase):
     def test_metaclass_constructor(self):
-        k, n = 3, 5 # number of blocks, block size
-        b1, b2 = 2, 3 # batch dimensions
+        k, n = 3, 5  # number of blocks, block size
+        b1, b2 = 2, 3  # batch dimensions
         base_operators = [torch.randn(k, n), torch.randn(b1, b2, k, n)]
+        subtest_names = ["non-batched input", "batched input"]
+        # repeats tests for both batched and non-batched tensors
+        for (base_op, test_name) in zip(base_operators, subtest_names):
+            with self.subTest(test_name):
+                base_diag = DiagLinearOperator(base_op)
+                linear_op = BlockDiagLinearOperator(base_diag)
 
-        for base_op in base_operators: # repeats tests for both batched and non-batched tensors
-            base_diag = DiagLinearOperator(base_op)
-            linear_op = BlockDiagLinearOperator(base_diag)
+                # checks that metaclass constructor returns a diagonal operator
+                # if a DiagLinearOperator is passed to BlockDiagLinearOperator
+                self.assertEqual(type(linear_op), DiagLinearOperator)
 
-            # checks that metaclass constructor returns a diagonal operator
-            # if a DiagLinearOperator is passed to BlockDiagLinearOperator
-            self.assertEqual(type(linear_op), DiagLinearOperator)
+                # matrix-vector-multiplication test
+                diag_values = base_op.flatten(
+                    start_dim=-2
+                )  # operator of non-block diagonal values
+                x = torch.randn_like(diag_values)
+                self.assertTrue(
+                    torch.equal(
+                        diag_values * x, (linear_op @ x.unsqueeze(-1)).squeeze(-1)
+                    )
+                )
 
-            # matrix-vector-multiplication test
-            diag_values = base_op.flatten(start_dim = -2) # operator of non-blocked diagonal values
-            x = torch.randn(diag_values.shape)
-            self.assertTrue(torch.equal(diag_values * x, (linear_op @ x.unsqueeze(-1)).squeeze(-1)))
+                # checks that the representation is numerically accurate
+                dense_operator = linear_op.to_dense()
+                truth_operator = torch.diag_embed(
+                    diag_values
+                )  # creates batch of diagonal operators
+                self.assertTrue(torch.equal(dense_operator, truth_operator))
 
-            # checks that the representation is numerically accurate
-            dense_operator = linear_op.to_dense()
-            truth_operator = torch.diag_embed(diag_values) # creates batch of diagonal operators
-            self.assertTrue(torch.equal(dense_operator, truth_operator))
-
-            with self.assertRaises(NotImplementedError):
-                # beside the dimensions not working out here, this should never
-                # be allowed as long as there is no special case for it, because
-                # matmuls with the resulting object will fail
-                BlockDiagLinearOperator(base_diag, block_dim=-2)
+                with self.assertRaisesRegex(
+                    NotImplementedError, "with block_dim = -2 != -3 is not supported"
+                ):
+                    # beside the dimensions not working out here, this should never
+                    # be allowed as long as there is no special case for it, because
+                    # matmuls with the resulting object will fail
+                    BlockDiagLinearOperator(base_diag, block_dim=-2)
 
 
 if __name__ == "__main__":

--- a/test/operators/test_block_diag_linear_operator.py
+++ b/test/operators/test_block_diag_linear_operator.py
@@ -4,11 +4,7 @@ import unittest
 
 import torch
 
-from linear_operator.operators import (
-    BlockDiagLinearOperator,
-    DiagLinearOperator,
-    DenseLinearOperator,
-)
+from linear_operator.operators import BlockDiagLinearOperator, DenseLinearOperator, DiagLinearOperator
 from linear_operator.test.linear_operator_test_case import LinearOperatorTestCase
 
 
@@ -68,9 +64,7 @@ class TestBlockDiagLinearOperatorMultiBatch(LinearOperatorTestCase, unittest.Tes
         for i in range(2):
             for j in range(6):
                 for k in range(5):
-                    actual[i, k, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = blocks[
-                        i, k, j
-                    ]
+                    actual[i, k, j * 4 : (j + 1) * 4, j * 4 : (j + 1) * 4] = blocks[i, k, j]
         return actual
 
 
@@ -91,26 +85,16 @@ class TestBlockDiagLinearOperatorMetaClass(unittest.TestCase):
                 self.assertEqual(type(linear_op), DiagLinearOperator)
 
                 # matrix-vector-multiplication test
-                diag_values = base_op.flatten(
-                    start_dim=-2
-                )  # operator of non-block diagonal values
+                diag_values = base_op.flatten(start_dim=-2)  # operator of non-block diagonal values
                 x = torch.randn_like(diag_values)
-                self.assertTrue(
-                    torch.equal(
-                        diag_values * x, (linear_op @ x.unsqueeze(-1)).squeeze(-1)
-                    )
-                )
+                self.assertTrue(torch.equal(diag_values * x, (linear_op @ x.unsqueeze(-1)).squeeze(-1)))
 
                 # checks that the representation is numerically accurate
                 dense_operator = linear_op.to_dense()
-                truth_operator = torch.diag_embed(
-                    diag_values
-                )  # creates batch of diagonal operators
+                truth_operator = torch.diag_embed(diag_values)  # creates batch of diagonal operators
                 self.assertTrue(torch.equal(dense_operator, truth_operator))
 
-                with self.assertRaisesRegex(
-                    NotImplementedError, "with block_dim = -2 != -3 is not supported"
-                ):
+                with self.assertRaisesRegex(NotImplementedError, "with block_dim = -2 != -3 is not supported"):
                     # beside the dimensions not working out here, this should never
                     # be allowed as long as there is no special case for it, because
                     # matmuls with the resulting object will fail


### PR DESCRIPTION
Moving over from [this PR](https://github.com/cornellius-gp/gpytorch/pull/2093).

>BlockDiagLazyTensor's matmul method fails with a dimension mismatch, when BlockDiagLazyTensor is constructed with a DiagLazyTensor as the base_lazy_tensor argument. We hit this case in a BoTorch test, and I added it to the TestBlockDiagLazyTensorMetaClass below.
>
>@Balandat and I thought that intercepting the construction of the BlockDiagLazyTensor and returning a vanilla DiagLazyTensor in this case would be a nice solution, instead of introducing another special case to matmul. This PR implements this feature via the _MetaBlockDiagLazyTensor constructor.
