### PR TITLE
Allow "-1" syntax for expand dimensions

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -1481,7 +1481,7 @@ class LinearOperator(ABC):
         """
         if len(sizes) == 1 and hasattr(sizes, "__iter__"):
             sizes = sizes[0]
-        if len(sizes) < 2 or tuple(sizes[-2:]) != self.matrix_shape:
+        if len(sizes) < 2 or tuple(sizes[-2:]) not in {tuple(self.matrix_shape), (-1, -1)}:
             raise RuntimeError(
                 "Invalid expand arguments {}. Currently, repeat only works to create repeated "
                 "batches of a 2D LinearOperator.".format(tuple(sizes))


### PR DESCRIPTION
A "-1" in the arguments to `expand` means that the size of that dimension is not be changed. This is used in torch's distrbutions and without this support passing in LinearOperators into torch distributions raises a (spurious) error. This adds support (+ a test) for this.