### PR TITLE
Update _linear_operator.py

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2556,6 +2556,8 @@ class LinearOperator(ABC):
         from .sum_linear_operator import SumLinearOperator
         from .zero_linear_operator import ZeroLinearOperator
 
+        import numbers
+
         if isinstance(other, ZeroLinearOperator):
             return self
         elif isinstance(other, DiagLinearOperator):
@@ -2568,6 +2570,8 @@ class LinearOperator(ABC):
             new_self = self if self.shape[:-2] == shape[:-2] else self._expand_batch(shape[:-2])
             new_other = other if other.shape[:-2] == shape[:-2] else other._expand_batch(shape[:-2])
             return SumLinearOperator(new_self, new_other)
+        elif isinstance(other,numbers.Number) and other==0:
+            return self
         else:
             return SumLinearOperator(self, other)
 

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import functools
 import math
+import numbers
 import warnings
 from abc import ABC, abstractmethod
 from copy import deepcopy
@@ -2546,17 +2547,13 @@ class LinearOperator(ABC):
 
         return samples
 
-    def __add__(self, other: Union[torch.Tensor, LinearOperator, float]) -> LinearOperator:
-        from torch import Tensor
-
+    def __add__(self, other: Union[Tensor, LinearOperator, float]) -> LinearOperator:
         from .added_diag_linear_operator import AddedDiagLinearOperator
         from .dense_linear_operator import to_linear_operator
         from .diag_linear_operator import DiagLinearOperator
         from .root_linear_operator import RootLinearOperator
         from .sum_linear_operator import SumLinearOperator
         from .zero_linear_operator import ZeroLinearOperator
-
-        import numbers
 
         if isinstance(other, ZeroLinearOperator):
             return self

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2570,7 +2570,7 @@ class LinearOperator(ABC):
             new_self = self if self.shape[:-2] == shape[:-2] else self._expand_batch(shape[:-2])
             new_other = other if other.shape[:-2] == shape[:-2] else other._expand_batch(shape[:-2])
             return SumLinearOperator(new_self, new_other)
-        elif isinstance(other,numbers.Number) and other==0:
+        elif isinstance(other, numbers.Number) and other == 0:
             return self
         else:
             return SumLinearOperator(self, other)


### PR DESCRIPTION
Add additional LinearOperator.__add__ case for Pythonic addition operations with the builtin sum() function. After other common use-cases, check if other is a numeric Python type and equal to zero, and if so, return self.

Fixes #8.