### PR TITLE
Removing `deepcopy` in `add` because of downstream failure in BoTorch

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2557,7 +2557,7 @@ class LinearOperator(ABC):
         from .zero_linear_operator import ZeroLinearOperator
 
         if isinstance(other, ZeroLinearOperator):
-            return deepcopy(self)
+            return self
         elif isinstance(other, DiagLinearOperator):
             return AddedDiagLinearOperator(self, other)
         elif isinstance(other, RootLinearOperator):


### PR DESCRIPTION
The addition of the `deepcopy` in the generic `__add__` led to downstream failures in BoTorch. This PR removes the `deepcopy`.