### PR TITLE
Performant Scaling of `BlockDiagLinearOperator` by `DiagLinearOperator`

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -558,12 +558,7 @@ class LinearOperator(ABC):
         if isinstance(self, DenseLinearOperator) or isinstance(other, DenseLinearOperator):
             return DenseLinearOperator(self.to_dense() * other.to_dense())
         else:
-            left_linear_op = self if self._root_decomposition_size() < other._root_decomposition_size() else other
-            right_linear_op = other if left_linear_op is self else self
-            return MulLinearOperator(
-                left_linear_op.root_decomposition(),
-                right_linear_op.root_decomposition(),
-            )
+            return MulLinearOperator(self, other)
 
     def _preconditioner(self) -> Tuple[Callable, "LinearOperator", torch.Tensor]:
         """

--- a/linear_operator/operators/block_diag_linear_operator.py
+++ b/linear_operator/operators/block_diag_linear_operator.py
@@ -153,8 +153,9 @@ class BlockDiagLinearOperator(BlockLinearOperator, metaclass=_MetaBlockDiagLinea
             return BlockDiagLinearOperator(self.base_linear_op @ other.base_linear_op)
         # special case if we have a DiagLinearOperator
         if isinstance(other, DiagLinearOperator):
-            diag_reshape = other._diag.view(*self.base_linear_op.shape[:-2], 1, -1)
-            return BlockDiagLinearOperator(self.base_linear_op * diag_reshape)
+            diag_reshape = other._diag.view(*self.base_linear_op.shape[:-1])
+            diag = DiagLinearOperator(diag_reshape)
+            return BlockDiagLinearOperator(self.base_linear_op @ diag)
         return super().matmul(other)
 
     @cached(name="svd")

--- a/linear_operator/operators/block_diag_linear_operator.py
+++ b/linear_operator/operators/block_diag_linear_operator.py
@@ -153,6 +153,7 @@ class BlockDiagLinearOperator(BlockLinearOperator, metaclass=_MetaBlockDiagLinea
             return BlockDiagLinearOperator(self.base_linear_op @ other.base_linear_op)
         # special case if we have a DiagLinearOperator
         if isinstance(other, DiagLinearOperator):
+            # matmul is going to be cheap because of the special casing in DiagLinearOperator
             diag_reshape = other._diag.view(*self.base_linear_op.shape[:-1])
             diag = DiagLinearOperator(diag_reshape)
             return BlockDiagLinearOperator(self.base_linear_op @ diag)

--- a/linear_operator/operators/cat_linear_operator.py
+++ b/linear_operator/operators/cat_linear_operator.py
@@ -366,6 +366,9 @@ class CatLinearOperator(LinearOperator):
         )
         return res
 
+    def to_dense(self):
+        return torch.cat([to_dense(L) for L in self.linear_ops], dim=self.cat_dim)
+
     def inv_quad_logdet(self, inv_quad_rhs=None, logdet=False, reduce_inv_quad=True):
         res = super().inv_quad_logdet(inv_quad_rhs, logdet, reduce_inv_quad)
         return tuple(r.to(self.device) for r in res)

--- a/linear_operator/operators/dense_linear_operator.py
+++ b/linear_operator/operators/dense_linear_operator.py
@@ -23,7 +23,7 @@ class DenseLinearOperator(LinearOperator):
         Args:
         - tsr (Tensor: matrix) a Tensor
         """
-        super(DenseLinearOperator, self).__init__(tsr)
+        super().__init__(tsr)
         self.tensor = tsr
 
     def _cholesky_solve(self, rhs, upper=False):
@@ -76,13 +76,7 @@ class DenseLinearOperator(LinearOperator):
         elif isinstance(other, torch.Tensor):
             return DenseLinearOperator(self.tensor + other)
         else:
-            return super(DenseLinearOperator, self).__add__(other)
-
-    def mul(self, other):
-        if isinstance(other, DenseLinearOperator):
-            return DenseLinearOperator(self.tensor * other.tensor)
-        else:
-            return super(DenseLinearOperator, self).mul(other)
+            return super().__add__(other)
 
 
 def to_linear_operator(obj: Union[torch.Tensor, LinearOperator]) -> LinearOperator:

--- a/linear_operator/operators/mul_linear_operator.py
+++ b/linear_operator/operators/mul_linear_operator.py
@@ -22,11 +22,14 @@ class MulLinearOperator(LinearOperator):
         Args:
             - linear_ops (A list of LinearOperator) - A list of LinearOperator to multiplicate with.
         """
+        if left_linear_op._root_decomposition_size() < right_linear_op._root_decomposition_size():
+            left_linear_op, right_linear_op = right_linear_op, left_linear_op
+
         if not isinstance(left_linear_op, RootLinearOperator):
             left_linear_op = left_linear_op.root_decomposition()
         if not isinstance(right_linear_op, RootLinearOperator):
             right_linear_op = right_linear_op.root_decomposition()
-        super(MulLinearOperator, self).__init__(left_linear_op, right_linear_op)
+        super().__init__(left_linear_op, right_linear_op)
         self.left_linear_op = left_linear_op
         self.right_linear_op = right_linear_op
 
@@ -62,7 +65,7 @@ class MulLinearOperator(LinearOperator):
             left_res = left_res.view(*output_batch_shape, n, rank, m)
             res = left_res.mul_(left_root.unsqueeze(-1)).sum(-2)
         # This is the case where we're not doing a root decomposition, because the matrix is too small
-        else:
+        else:  # Dead?
             res = (self.left_linear_op.to_dense() * self.right_linear_op.to_dense()).matmul(rhs)
         res = res.squeeze(-1) if is_vector else res
         return res


### PR DESCRIPTION
The primary goal of this PR is to enable the efficient scaling of `BlockDiagLinearOperators` by `DiagLinearOperators`. This will allow us to remove a special case in [BoTorch's outcome transform](https://github.com/pytorch/botorch/blob/5f2028d8f6883eed29fe789bbc54f240937f6125/botorch/models/transforms/outcome.py#L389). 

In order to achieve this, this PR modifies and adds special cases to `DiagLinearOperator` and `BlockDiagLinearOperator`'s `matmul`.

I tested the notebook that exhibited the regression by patching in the function definitions here and ended up with a 16 second runtime - as opposed to 30+ minutes before.