### PR TITLE
Removing `evaluate_kernel`

### DIFF
--- a/linear_operator/operators/added_diag_linear_operator.py
+++ b/linear_operator/operators/added_diag_linear_operator.py
@@ -186,7 +186,3 @@ class AddedDiagLinearOperator(SumLinearOperator):
             evals = evals_ + self._diag_tensor._diagonal()
             return evals, evecs
         return super()._symeig(eigenvectors=eigenvectors)
-
-    def evaluate_kernel(self) -> LinearOperator:
-        added_diag_linear_op = self.representation_tree()(*self.representation())
-        return added_diag_linear_op._linear_op + added_diag_linear_op._diag_tensor


### PR DESCRIPTION
This PR aims at removing `evaluate_kernel` from the `linear_operator` package. This was already suggested in a comment in the code and makes sense since -- as far as I can tell -- it is a no-op for all operators in this package.

The main question at this point seems to be if additional changes are required in GPyTorch, which defines `LazyEvaluatedKernelTensor` and should therefore take care of any of its implementation specifics.