### PR TITLE
Add basic example notebook

### DIFF
--- a/examples/LinearOperator_demo.ipynb
+++ b/examples/LinearOperator_demo.ipynb
@@ -1,0 +1,956 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "failing-director",
+   "metadata": {},
+   "source": [
+    "# Demo: `LinearOperator`\n",
+    "\n",
+    "`linear_operator` (https://github.com/cornellius-gp/linear_operator) is a library for structured linear algebra built on PyTorch.\n",
+    "\n",
+    "Due to its history as the linear algebra backend for GPyTorch (), it assumes (with a few exceptions) that the involved matrices symmetric positive definite. This can and should be relaxed to more general structured matrices (indefinite, non-square) as we think about developing `linear_operator` into a more general library.\n",
+    "\n",
+    "\n",
+    "### Installation:\n",
+    "\n",
+    "**Stable:**\n",
+    "`pip install linear_operator`\n",
+    "\n",
+    "**Lastest main branch:**\n",
+    "`pip install git+https://github.com/cornellius-gp/linear_operator.git`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "tracked-algebra",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Tuple\n",
+    "\n",
+    "import torch\n",
+    "\n",
+    "from linear_operator.operators import DiagLinearOperator, BlockDiagLinearOperator, KroneckerProductLinearOperator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "retired-farming",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def make_pd(n: int, b: Tuple[int, ...]=()):\n",
+    "    \"\"\"Helper for generating random positive definite matrices.\"\"\"\n",
+    "    a = torch.rand(*b, n, n)\n",
+    "    return a @ a.transpose(-1, -2) + torch.diag_embed(0.1 + torch.rand(*b, n))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "arbitrary-leader",
+   "metadata": {},
+   "source": [
+    "### Simple example: Diagonal matrices\n",
+    "\n",
+    "Consider diagonal matrices of size $n \\times n$\n",
+    "\n",
+    "Matmul is $\\mathcal O(n)$ using he underlying structure, but $\\mathcal O(n^2)$ not using structure. The same is true for memory complexity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "opposite-invite",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note: Using n > 2500 would demonstrate the benefits even more, but\n",
+    "# there is a weird pytorch bug with eigh that results in failures with\n",
+    "# certain setups: https://github.com/pytorch/pytorch/issues/83818\n",
+    "\n",
+    "diag1 = 0.1 + torch.rand(2500)\n",
+    "diag2 = 0.1 + torch.rand(2500)\n",
+    "\n",
+    "Diag1 = diag1.diag() # 25M elements\n",
+    "Diag2 = diag2.diag() # 25M elements\n",
+    "\n",
+    "Diag1_lo = DiagLinearOperator(diag1)  # 5K elements\n",
+    "Diag2_lo = DiagLinearOperator(diag2)  # 5K elements"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "after-operator",
+   "metadata": {},
+   "source": [
+    "#### Addition\n",
+    "\n",
+    "Diagonality (ness?) is closed under addition. `LinearOperator` understands that (note that the result is again a `DiagLinearOperator` rather than a dense Tensor)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "inner-circus",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<linear_operator.operators.diag_linear_operator.DiagLinearOperator at 0x111590af0>"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "result = Diag1_lo + Diag2_lo\n",
+    "result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1523ab7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert torch.equal(result.diagonal(), diag1 + diag2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sealed-advertiser",
+   "metadata": {},
+   "source": [
+    "#### Matmul\n",
+    "\n",
+    "Matrix-multiplying diagonal matrices just means creating a diagonal matrix with the element-wise product of the diagonals as its diagonal. Naive time and memory complexity is $\\mathcal O(n^2)$, using structure it is $\\mathcal O(n)$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "exceptional-plaza",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "matmul = (Diag1 @ Diag2).diag()\n",
+    "matmul_lo = (Diag1_lo @ Diag2_lo).diagonal()\n",
+    "\n",
+    "assert torch.equal(matmul, matmul_lo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "actual-allen",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "17.3 ms ± 245 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_d = %timeit -o (Diag1 @ Diag2).diag()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "composite-wholesale",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.26 µs ± 46.6 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_lo = %timeit -o (Diag1_lo @ Diag2_lo).diagonal()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "6500b03f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "5324.419178392022"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_d.average / t_lo.average"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "specialized-better",
+   "metadata": {},
+   "source": [
+    "Improvements: \n",
+    "- $2,500$ -fold reduction in memory\n",
+    "- more than 3 orders of magnitude faster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "critical-canon",
+   "metadata": {},
+   "source": [
+    "#### Eigendecomposition\n",
+    "\n",
+    "This uses `__torch_function__` in order to dispatch `torch.symeig` to a custom implementation that essentially just returns the diagonal elements and the identity matrix (should sort the evals and permute the evecs to have the exact same behavior, that's an easy thing to do).\n",
+    "\n",
+    "Time complexity goes from $\\mathcal O(n^3)$ to $\\mathcal O(1)$ (without sorting). Memory complexity goes from $\\mathcal O(n^2)$ to $\\mathcal O(n)$. \n",
+    "\n",
+    "Of course if the user was aware of the structure, they could do this manually. The point is that `LinearOperator` does these things automatically (for more complex examples see below). Think of it like operator fusing on steroids (with the steroids being exploiting linear algebra simplifications for structured operators - this is something that basic notions of sparsity cannot do achieve)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "aboriginal-encyclopedia",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evals, evecs = torch.linalg.eigh(Diag1)\n",
+    "evals_lo, evecs_lo = torch.linalg.eigh(Diag1_lo)\n",
+    "\n",
+    "assert torch.allclose(evals, torch.sort(evals_lo).values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "valued-sending",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "915 ms ± 11.5 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_d = %timeit -o torch.linalg.eigh(Diag1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "dress-stranger",
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "4.98 µs ± 33.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_lo = %timeit -o torch.linalg.eigh(Diag1_lo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "250930e8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "183581.73564684932"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_d.average / t_lo.average"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "useful-learning",
+   "metadata": {},
+   "source": [
+    "Improvements: \n",
+    "- $2,500$ -fold reduction in memory\n",
+    "- 5 orders of magnitude faster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fiscal-perspective",
+   "metadata": {},
+   "source": [
+    "### Simpl-ish example: Block-Diagonal matrices\n",
+    "\n",
+    "Matmul is $\\mathcal O(n)$ using structure, but $\\mathcal O(n^2)$ not using structure. Same for memory complexity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "seasonal-flesh",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# create a 2000 x 2000 block-diagonal matrix with 200 random symmetric 10 x 10 matrices on the (block)diagonal\n",
+    "BDiag_lo = BlockDiagLinearOperator(make_pd(10, (200,)))\n",
+    "\n",
+    "# instatiate the full matrix\n",
+    "BDiag = BDiag_lo.to_dense()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "musical-connection",
+   "metadata": {},
+   "source": [
+    "#### Matrix-vector Multiplication (MVM)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "growing-swing",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v = torch.rand(2000, 1)\n",
+    "\n",
+    "mvm = BDiag @ v\n",
+    "mvm_lo = BDiag_lo @ v\n",
+    "\n",
+    "assert torch.allclose(mvm, mvm_lo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "sapphire-nepal",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "324 µs ± 2.07 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_d = %timeit -o BDiag @ v"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "dramatic-vietnamese",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "48.1 µs ± 1.06 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_lo = %timeit -o BDiag_lo @ v"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "e3e51f90",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "6.734157966151394"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_d.average / t_lo.average"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "religious-thermal",
+   "metadata": {},
+   "source": [
+    "Improvements: \n",
+    "- $2,000$ -fold reduction in memory\n",
+    "- $\\approx 6$ times faster (dense matmuls are just really optimized so not a ton to gain...)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "local-bouquet",
+   "metadata": {},
+   "source": [
+    "#### SVD\n",
+    "\n",
+    "Can construct the SVD of a Kronecker product from the SVD of the constitutent matrices. This allows us to compute the SVDs of 200 10x10 matrices in batch under the hood rather than the SVD of a 2000 x 2000 matrix.\n",
+    "\n",
+    "In math, since time complexity for computing SVDs is cubic, if there are $n_b$ blocks of size $n \\times n$ in the matrix, then we reduce complexity from $\\mathcal O (n_b^3 n^3)$ to $\\mathcal O (n_b n^3)$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "traditional-weight",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# TODO: This worked with torch.svd in he past, may need to patch `__torch_function__` for eigh\n",
+    "\n",
+    "U, S, V = torch.linalg.svd(BDiag)\n",
+    "U_lo, S_lo, V_lo = torch.linalg.svd(BDiag_lo)\n",
+    "\n",
+    "torch.allclose(S, torch.sort(S_lo, descending=True).values, atol=1e-5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "explicit-procedure",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "506 ms ± 30.9 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_d = %timeit -o torch.linalg.svd(BDiag)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "appropriate-chester",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "7.33 µs ± 98.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_lo = %timeit -o torch.linalg.svd(BDiag_lo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "621900f8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "69007.02781403827"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_d.average / t_lo.average"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sharing-identifier",
+   "metadata": {},
+   "source": [
+    "Improvements: \n",
+    "- more than 4 orders of magnitude faster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "clean-potential",
+   "metadata": {},
+   "source": [
+    "### More complex: Kronecker matrices\n",
+    "\n",
+    "If $A$ is $n \\times n$ and $B$ is $m \\times m$, then $A\\otimes B$ is $nm \\times nm$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "light-infrastructure",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "A = make_pd(20)\n",
+    "B = make_pd(500)\n",
+    "\n",
+    "Kron_lo = KroneckerProductLinearOperator(A, B)\n",
+    "Kron = Kron_lo.to_dense()\n",
+    "\n",
+    "assert torch.allclose(Kron, torch.kron(A, B))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "continent-rubber",
+   "metadata": {},
+   "source": [
+    "#### MVM\n",
+    "\n",
+    "Naively, MVM is $\\mathcal O(n^2m^2)$ time. However, exploiting Kronecker structure, we get $\\mathcal O (nm (n+m))$ time. Memory complexity goes from $\\mathcal O(n^2m^2)$ to $\\mathcal O(n^2 + m^2)$"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "treated-thong",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "v = torch.rand(Kron_lo.shape[-1], 1)\n",
+    "\n",
+    "mvm = Kron @ v\n",
+    "mvm_lo = Kron_lo @ v\n",
+    "\n",
+    "assert torch.allclose(mvm, mvm_lo)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "presidential-communications",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15.3 ms ± 240 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_d = %timeit -o Kron @ v"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "toxic-prediction",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "93 µs ± 1.46 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_lo = %timeit -o Kron_lo @ v"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "id": "081224a9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "164.64672578765354"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_d.average / t_lo.average"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "familiar-sauce",
+   "metadata": {},
+   "source": [
+    "Improvements:\n",
+    "- $200,000$ -fold reduction in memory\n",
+    "- more than 2 order so magnitude faster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "universal-measurement",
+   "metadata": {},
+   "source": [
+    "### Even more fun with Kronecker structure"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "academic-jones",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from linear_operator.operators import KroneckerProductLinearOperator, ConstantDiagLinearOperator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "coated-favor",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Kron_lt = KroneckerProductLinearOperator(A, B)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "searching-perth",
+   "metadata": {},
+   "source": [
+    "Let's add some (constant) diagonal: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "superb-thinking",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<linear_operator.operators.kronecker_product_added_diag_linear_operator.KroneckerProductAddedDiagLinearOperator at 0x1077dac70>"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Diag_lt = ConstantDiagLinearOperator(1 + torch.rand(1), Kron_lt.shape[-1])\n",
+    "Diag = Diag_lt.to_dense()\n",
+    "\n",
+    "KaddD = Kron + Diag\n",
+    "KaddD_lt = Kron_lt + Diag_lt\n",
+    "KaddD_lt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "handed-adapter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "assert torch.allclose(KaddD_lt.to_dense(), KaddD)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "boolean-subscriber",
+   "metadata": {},
+   "source": [
+    "#### Solve\n",
+    "\n",
+    "Solving $(A \\otimes B + a I)x = v$ naively means solving a $nm \\times nm$ linear system.\n",
+    "\n",
+    "We can be smart by instead noting that computing the inverse of $A \\otimes B + a I$ can be done cheaply:\n",
+    "1. We perform an eigendecomposition $A \\otimes B = \\sum_j e_j v_jv_j^T$. This can be done cheaply b/c the eigendecomposition of  $A \\otimes B$ can be constructed from the (small and cheap-to-compute) eigendecompositions of $A$ and $B$, respectively.\n",
+    "2. The eigendecomposition of $A \\otimes B + a I$ is just the eigendecomposition of $A \\otimes B$ plus a spectral shift of the eigenvalues $e_j$ by $a$.\n",
+    "3. The inverse of $A \\otimes B + a I$ is obtained by simply taking the reciprocals of the eigenvalues in its eigendecomposition.\n",
+    "\n",
+    "At the end of the day, this means that we can go from $\\mathcal O(n^3m^3)$ to $\\mathcal O(n^3 + m^3)$ complexity for the solve. We don't have to do anything other than ensuring that we express $A \\otimes B$ and the constant diagonal with the right operators, the rest we get for free (modulo registering this with `solve` via `__torch_function__`). Of course this is true for additional Kronecker factors, i.e. we go from $\\mathcal O(\\Pi_i n_i^3)$ to $\\mathcal O(\\sum_i n_i^3)$\n",
+    "\n",
+    "One thing to be careful about are numerical robustness issues, which can be an issue when computing eigendecompositions. In general, hairy linear algebra should happen in double not float..."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "meaning-butler",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x = torch.linalg.solve(KaddD, v)\n",
+    "x_lt = torch.linalg.solve(KaddD_lt, v)\n",
+    "\n",
+    "assert torch.allclose(x, x_lt, atol=1e-2, rtol=1e-4)  # hard solve, need to increase tolerance here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "id": "juvenile-wichita",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.15 s ± 35.4 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_d = %timeit -o torch.linalg.solve(Kron + Diag, v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "id": "identified-berlin",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "20.1 ms ± 137 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_lo = %timeit -o torch.linalg.solve(Kron_lt + Diag_lt, v)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "id": "d17b0ab5",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "57.28185047652546"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_d.average / t_lo.average"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sized-daily",
+   "metadata": {},
+   "source": [
+    "Improvements:\n",
+    "- $200,000$ -fold reduction in memory\n",
+    "- $\\approx 50$ times faster"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "verbal-garlic",
+   "metadata": {},
+   "source": [
+    "### A non-PSD example: Triangular matrices \n",
+    "\n",
+    "We have `torch.triangular_solve` to get solve complexity down from $\\mathcal O(n^3)$ to $\\mathcal O(n^2)$, but the user has to fully trace through all of their code to understand when it's safe to call it. If we can retain the structural information, we can just dispatch to the right solve automatically, allowing us to write structure-agnostic code and get the linear algebra optimziations for free."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "determined-native",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from linear_operator.operators import TriangularLinearOperator"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "id": "major-developer",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tri = torch.eye(500) + torch.rand(500, 500, dtype=torch.double).tril()\n",
+    "tri_lo = TriangularLinearOperator(tri)\n",
+    "\n",
+    "assert torch.equal(tri, tri_lo.to_dense())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "id": "acting-cylinder",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tri_inv = torch.inverse(tri)\n",
+    "tri_lo_inv = tri_lo.inverse()  # TODO: Handle in torch.inverse by registering via __torch_function__\n",
+    "\n",
+    "assert torch.allclose(tri_inv, tri_lo_inv.to_dense())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "id": "enhanced-patrick",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3.34 ms ± 90 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_d = %timeit -o torch.inverse(tri)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "id": "mature-balance",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "672 ns ± 3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)\n"
+     ]
+    }
+   ],
+   "source": [
+    "t_lo = %timeit -o tri_lo.inverse()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "id": "98e3a2f0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "4973.516163490839"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t_d.average / t_lo.average"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "premium-picnic",
+   "metadata": {},
+   "source": [
+    "Improvements:\n",
+    "- uses half of the memory\n",
+    "- $\\approx 5,000$ times faster"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/linear_operator/operators/block_linear_operator.py
+++ b/linear_operator/operators/block_linear_operator.py
@@ -23,7 +23,7 @@ class BlockLinearOperator(LinearOperator):
 
     Args:
         - :attr:`base_linear_op` (LinearOperator or Tensor):
-            Must be at least 3 dimenional.
+            Must be at least 3 dimensional.
         - :attr:`block_dim` (int):
             The dimension that specifies blocks.
     """
@@ -149,7 +149,12 @@ class BlockLinearOperator(LinearOperator):
         return self.__class__(ConstantMulLinearOperator(self.base_linear_op, other))
 
     def _transpose_nonbatch(self):
-        return self.__class__(self.base_linear_op._transpose_nonbatch())
+        base_op = self.base_linear_op
+        if isinstance(base_op, LinearOperator):
+            new_base_op = base_op._transpose_nonbatch()
+        else:
+            new_base_op = base_op.transpose(-1, -2)
+        return self.__class__(new_base_op)
 
     def zero_mean_mvn_samples(self, num_samples):
         res = self.base_linear_op.zero_mean_mvn_samples(num_samples)


### PR DESCRIPTION
Adds an example ipynb that showcases some basic functionality of LinearOperator and compares the speedups/memory savings compared to a dense tensor approach.

A couple of things are broken that worked on a previuos version, presumably we need to do some more `__torch_function__` updates to deal with some of the deprecations on the pytorch end.