### PR TITLE
Update LO.__getitem__ to handle broadcasted tensor indices.

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2634,8 +2634,7 @@ class LinearOperator(ABC):
             tensor_index_shape = torch.broadcast_shapes(*[idx.shape for idx in orig_indices if torch.is_tensor(idx)])
             # Flatten existing tensor indices
             flattened_orig_indices = [
-                idx.expand(tensor_index_shape).reshape(-1) if torch.is_tensor(idx) else idx
-                for idx in orig_indices
+                idx.expand(tensor_index_shape).reshape(-1) if torch.is_tensor(idx) else idx for idx in orig_indices
             ]
             # Convert all indices into tensor indices
             (

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2634,7 +2634,7 @@ class LinearOperator(ABC):
             tensor_index_shape = torch.broadcast_shapes(*[idx.shape for idx in orig_indices if torch.is_tensor(idx)])
             # Flatten existing tensor indices
             flattened_orig_indices = [
-                idx.expand(tensor_index_shape).contiguous().view(-1) if torch.is_tensor(idx) else idx
+                idx.expand(tensor_index_shape).reshape(-1) if torch.is_tensor(idx) else idx
                 for idx in orig_indices
             ]
             # Convert all indices into tensor indices

--- a/linear_operator/operators/cat_linear_operator.py
+++ b/linear_operator/operators/cat_linear_operator.py
@@ -246,7 +246,7 @@ class CatLinearOperator(LinearOperator):
         elif torch.is_tensor(cat_dim_indices):
             if cat_dim_indices.dim() > 1:
                 # Supporting broadcasting tensor indices for CatLinearOpeartor is very challenging to implement,
-                # and probvably not a featuer we need.
+                # and probably not a feature we need.
                 raise RuntimeError(
                     "CatLinearOperator does not support broadcasted tensor indexes. "
                     f"Got tensor indices of size {[idx.shape for idx in indices if torch.is_tensor(idx)]}."

--- a/linear_operator/operators/cat_linear_operator.py
+++ b/linear_operator/operators/cat_linear_operator.py
@@ -244,6 +244,14 @@ class CatLinearOperator(LinearOperator):
                     res_list.append(res)
 
         elif torch.is_tensor(cat_dim_indices):
+            if cat_dim_indices.dim() > 1:
+                # Supporting broadcasting tensor indices for CatLinearOpeartor is very challenging to implement,
+                # and probvably not a featuer we need.
+                raise RuntimeError(
+                    "CatLinearOperator does not support broadcasted tensor indexes. "
+                    f"Got tensor indices of size {[idx.shape for idx in indices if torch.is_tensor(idx)]}."
+                )
+
             # Find out for which indices we switch to different tensors
             target_tensors = self.idx_to_tensor_idx[cat_dim_indices]
             does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=bool_compat, device=self.device)

--- a/test/operators/test_cat_linear_operator.py
+++ b/test/operators/test_cat_linear_operator.py
@@ -116,6 +116,12 @@ class TestCatLinearOperatorBatchCat(LinearOperatorTestCase, unittest.TestCase):
     def evaluate_linear_op(self, linear_op):
         return self.psd_mat.detach().clone().requires_grad_()
 
+    def test_getitem_broadcasted_tensor_index(self):
+        linear_op = self.create_linear_op()
+
+        with self.assertRaises(RuntimeError):
+            linear_op[torch.tensor([0, 1, 1]).view(-1, 1), ...]
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
In GPyTorch, we occasionally use broadcasted tensor indices such as the following:

- idx_a - size [18, 4, 1]
- idx_b - size [18, 1, 4]

covar_matrix[..., idx_a, idx_b]  # Returns a matrix of size [... x 18 x 4 x 4].

This PR ensures that we can use broadcasting tensor indices (especially those that introduce new dimensions).

[Needed for https://github.com/cornellius-gp/gpytorch/pull/2140]