### PR TITLE
Register torch.isclose

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2716,7 +2716,7 @@ class LinearOperator(ABC):
         # Regardless, if possible it would make sense to overwrite this method on the subclasses if that can
         # be done without instantiating the full tensor.
         warnings.warn(
-            f"Converting {self.class.name} into a dense torch.Tensor due to a torch.isclose call. "
+            f"Converting {self.__class__.__name__} into a dense torch.Tensor due to a torch.isclose call. "
             "This may incur substantial performance and memory penalties.",
             PerformanceWarning,
         )

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -38,7 +38,7 @@ from ..utils.getitem import (
 from ..utils.lanczos import _postprocess_lanczos_root_inv_decomp
 from ..utils.memoize import _is_in_cache_ignore_all_args, _is_in_cache_ignore_args, add_to_cache, cached, pop_from_cache
 from ..utils.pinverse import stable_pinverse
-from ..utils.warnings import NumericalWarning
+from ..utils.warnings import NumericalWarning, PerformanceWarning
 from .linear_operator_representation_tree import LinearOperatorRepresentationTree
 
 _HANDLED_FUNCTIONS = {}
@@ -2715,6 +2715,11 @@ class LinearOperator(ABC):
         # if the represented tensor is massive (in which case using this method may not make a lot of sense.
         # Regardless, if possible it would make sense to overwrite this method on the subclasses if that can
         # be done without instantiating the full tensor.
+        warnings.warn(
+            f"Converting {self.class.name} into a dense torch.Tensor due to a torch.isclose call. "
+            "This may incur substantial performance and memory penalties.",
+            PerformanceWarning,
+        )
         return torch.isclose(to_dense(self), to_dense(other), rtol=rtol, atol=atol, equal_nan=equal_nan)
 
     def __matmul__(self, other: Union[torch.Tensor, LinearOperator]) -> Union[torch.Tensor, LinearOperator]:

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -1681,6 +1681,10 @@ class LinearOperator(ABC):
     def is_square(self) -> bool:
         return self.matrix_shape[0] == self.matrix_shape[1]
 
+    @_implements_symmetric(torch.isclose)
+    def isclose(self, other, rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False) -> Tensor:
+        return self._isclose(other, rtol=rtol, atol=atol, equal_nan=equal_nan)
+
     @_implements(torch.log)
     def log(self) -> "LinearOperator":
         # Only implemented by some LinearOperator subclasses
@@ -2705,6 +2709,13 @@ class LinearOperator(ABC):
 
         # We're done!
         return res
+
+    def _isclose(self, other, rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False) -> Tensor:
+        # As the default we can fall back to just calling isclose on the dense tensors. This is problematic
+        # if the represented tensor is massive (in which case using this method may not make a lot of sense.
+        # Regardless, if possible it would make sense to overwrite this method on the subclasses if that can
+        # be done without instantiating the full tensor.
+        return torch.isclose(to_dense(self), to_dense(other), rtol=rtol, atol=atol, equal_nan=equal_nan)
 
     def __matmul__(self, other: Union[torch.Tensor, LinearOperator]) -> Union[torch.Tensor, LinearOperator]:
         return self.matmul(other)

--- a/linear_operator/operators/dense_linear_operator.py
+++ b/linear_operator/operators/dense_linear_operator.py
@@ -3,8 +3,9 @@
 from typing import Union
 
 import torch
+from torch import Tensor
 
-from ._linear_operator import LinearOperator
+from ._linear_operator import LinearOperator, to_dense
 
 
 class DenseLinearOperator(LinearOperator):
@@ -44,6 +45,9 @@ class DenseLinearOperator(LinearOperator):
         # Perform the __getitem__
         res = self.tensor[(*batch_indices, row_index, col_index)]
         return self.__class__(res)
+
+    def _isclose(self, other, rtol: float = 1e-05, atol: float = 1e-08, equal_nan: bool = False) -> Tensor:
+        return torch.isclose(self.tensor, to_dense(other), rtol=rtol, atol=atol, equal_nan=equal_nan)
 
     def _matmul(self, rhs):
         return torch.matmul(self.tensor, rhs)

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -846,13 +846,13 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
 
     def test_is_close(self):
         linear_op = self.create_linear_op()
-        comparator = linear_op.to_dense().detach().clone()
-        comparator[..., 0, 0] += 1.0
+        other = linear_op.to_dense().detach().clone()
+        other[..., 0, 0] += 1.0
         if not isinstance(linear_op, DenseLinearOperator):
             with self.assertWarnsRegex(PerformanceWarning, "dense torch.Tensor due to a torch.isclose call"):
-                is_close = torch.isclose(linear_op, comparator)
+                is_close = torch.isclose(linear_op, other)
         else:
-            is_close = torch.isclose(linear_op, comparator)
+            is_close = torch.isclose(linear_op, other)
         self.assertFalse(torch.any(is_close[..., 0, 0]))
         is_close[..., 0, 0] = True
         self.assertTrue(torch.all(is_close))

--- a/linear_operator/utils/warnings.py
+++ b/linear_operator/utils/warnings.py
@@ -7,3 +7,11 @@ class NumericalWarning(RuntimeWarning):
     """
 
     pass
+
+
+class PerformanceWarning(RuntimeWarning):
+    """
+    Warning thrown when LinearOperators are used in a way that may incur large performance / memory penalties.
+    """
+
+    pass


### PR DESCRIPTION
This is called in some places inside the torch.distributions code when `validate_args=True`.

This is a pretty basic implementation and we probably don't want to do this kind of things if the linear operators are very large since `islose` returns a tensor of the same size as the (often implicitly represented) operator.

**TODO:** Add unit tests