### PR TITLE
Introduce reshape

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -1972,8 +1972,10 @@ class LinearOperator(ABC):
         """
         Alias for expand
         """
-        # TODO: Do we really want to do this? I guess the difference betwen reshape and
-        # expand is kind of unclear for LinearOperator.
+        # While for regular tensors expand doesn't handle a leading non-existing -1 dimension,
+        # reshape does. So we handle this conversion here.
+        if len(sizes) == len(self.shape) + 1 and sizes[0] == -1:
+            sizes = (1,) + sizes[1:]
         return self.expand(*sizes)
 
     @_implements_second_arg(torch.matmul)

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -1964,6 +1964,14 @@ class LinearOperator(ABC):
         self._set_requires_grad(val)
         return self
 
+    def reshape(self, *sizes: Union[torch.Size, Tuple[int, ...]]) -> LinearOperator:
+        """
+        Alias for expand
+        """
+        # TODO: Do we really want to do this? I guess the difference betwen reshape and
+        # expand is kind of unclear for LinearOperator.
+        return self.expand(*sizes)
+
     @_implements_second_arg(torch.matmul)
     def rmatmul(self, other: Union[torch.Tensor, "LinearOperator"]) -> Union[torch.Tensor, "LinearOperator"]:
         r"""

--- a/linear_operator/operators/triangular_linear_operator.py
+++ b/linear_operator/operators/triangular_linear_operator.py
@@ -83,6 +83,8 @@ class TriangularLinearOperator(LinearOperator, _TriangularLinearOperatorBase):
     def _expand_batch(self, batch_shape: torch.Size) -> "TriangularLinearOperator":
         if len(batch_shape) == 0:
             return self
+        if batch_shape[0] == -1:  # TODO: Should we allow this more generally?
+            batch_shape = torch.Size([1, *batch_shape[1:]])
         return self.__class__(tensor=self._tensor._expand_batch(batch_shape), upper=self.upper)
 
     def _get_indices(

--- a/linear_operator/operators/triangular_linear_operator.py
+++ b/linear_operator/operators/triangular_linear_operator.py
@@ -83,8 +83,6 @@ class TriangularLinearOperator(LinearOperator, _TriangularLinearOperatorBase):
     def _expand_batch(self, batch_shape: torch.Size) -> "TriangularLinearOperator":
         if len(batch_shape) == 0:
             return self
-        if batch_shape[0] == -1:  # TODO: Should we allow this more generally?
-            batch_shape = torch.Size([1, *batch_shape[1:]])
         return self.__class__(tensor=self._tensor._expand_batch(batch_shape), upper=self.upper)
 
     def _get_indices(

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -816,6 +816,12 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
         with self.assertRaisesRegex(RuntimeError, expected_msg):
             linear_op.expand(*expand_args)
 
+    def test_reshape(self):
+        # reshape is mostly an alias for expand, we just need to check the handling of a leading -1 dim
+        linear_op = self.create_linear_op()
+        expanded_op = linear_op.reshape(-1, *linear_op.shape)
+        self.assertEqual(expanded_op.shape, torch.Size([1]) + linear_op.shape)
+
     def test_float(self):
         linear_op = self.create_linear_op().double()
         evaluated = self.evaluate_linear_op(linear_op)


### PR DESCRIPTION
This function is used ubiquitously with tensors, so in order to make `LinearOperator` a drop-in replacement for tensors we need to use it.

`reshape` (other than view) will reallocate new memory if necessary - this concept doesn't really make a to of sense for `LinearOperator`s, so a straightforward thing to do is just to make this an alias for `expand` and not allow reshaping the last two (non-batch) dimensions for now. The current implementation of course only makes sense for square `LinearOperator`s (or rather operators where the non-batch dimensions don't change).