### PR TITLE
Cleaned up configuration for isort and black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,26 +16,38 @@ repos:
     hooks:
     -   id: flake8
         args: [--config=setup.cfg]
-        exclude: ^(examples/*)|(docs/*)
+        exclude: |
+            ^examples/
+            ^docs/
 -   repo: https://github.com/ambv/black
     rev: 22.3.0
     hooks:
     -   id: black
-        exclude: ^(build/*)|(docs/*)|(examples/*)
+        exclude: |
+            ^build/
+            ^docs/
+            ^examples/
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:
     -   id: isort
         language_version: python3
-        exclude: ^(build/*)|(docs/*)|(examples/*)
+        exclude: |
+            ^build/
+            ^docs/
+            ^examples/
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:
     -   id: require-ascii
-        exclude: ^(examples/.*\.ipynb)|(.github/ISSUE_TEMPLATE/*)
+        exclude: |
+            ^examples/.*\.ipynb
+            ^\.github/ISSUE_TEMPLATE/
     -   id: script-must-have-extension
     -   id: forbid-binary
-        exclude: ^(examples/*)|(test/examples/old_variational_strategy_model.pth)
+        exclude: |
+            ^examples/
+            ^test/examples/old_variational_strategy_model.pth
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
     rev: v1.1.13
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     -   id: isort
         language_version: python3
         exclude: ^(build/*)|(docs/*)|(examples/*)
-        args: [-w120, -m3, --tc, --project=gpytorch, "black"]
+        args: [-w120, -m3, --tc, --project=gpytorch]
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     -   id: isort
         language_version: python3
         exclude: ^(build/*)|(docs/*)|(examples/*)
-        args: [-w120, -m3, --tc, --project=gpytorch]
+        args: [-w120, -m3, --tc, --project=gpytorch, "black"]
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,14 +22,12 @@ repos:
     hooks:
     -   id: black
         exclude: ^(build/*)|(docs/*)|(examples/*)
-        args: [-l 120, --target-version=py37]
 -   repo: https://github.com/pre-commit/mirrors-isort
     rev: v5.10.1
     hooks:
     -   id: isort
         language_version: python3
         exclude: ^(build/*)|(docs/*)|(examples/*)
-        args: [-w120, -m3, --tc, --project=gpytorch]
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,6 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools_scm]
 local_scheme = "node-and-date"
 write_to = "./linear_operator/version.py"
+
+[tool.isort]
+profile = "black"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,8 +6,13 @@ build-backend = "setuptools.build_meta"
 local_scheme = "node-and-date"
 write_to = "./linear_operator/version.py"
 
+[tool.black]
+line-length = 120
+
 [tool.isort]
 # see https://pycqa.github.io/isort/docs/configuration/profiles.html#black
 profile = "black"
 combine_as_imports = true
 force_sort_within_sections = true
+include_trailing_comma = true
+multi_line_output=3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,4 +15,4 @@ profile = "black"
 combine_as_imports = true
 force_sort_within_sections = true
 include_trailing_comma = true
-multi_line_output=3
+multi_line_output = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,4 +7,7 @@ local_scheme = "node-and-date"
 write_to = "./linear_operator/version.py"
 
 [tool.isort]
+# see https://pycqa.github.io/isort/docs/configuration/profiles.html#black
 profile = "black"
+combine_as_imports = true
+force_sort_within_sections = true

--- a/setup.py
+++ b/setup.py
@@ -68,12 +68,15 @@ setup(
         "Source": "https://github.com/cornellius-gp/linear_operator/",
     },
     license="MIT",
-    classifiers=["Development Status :: 2 - Pre-Alpha", "Programming Language :: Python :: 3"],
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "Programming Language :: Python :: 3",
+    ],
     packages=find_packages(exclude=["test", "test.*"]),
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require={
-        "dev": ["black", "twine", "pre-commit"],
+        "dev": ["black==22.3.0", "twine", "pre-commit"],
         "test": ["flake8==4.0.1", "flake8-print==4.0.0"],
     },
     test_suite="test",


### PR DESCRIPTION
# In a Nutshell
Configuration between linters `isort` and `black` was only handled in pre-commit hooks and could lead to conflicts.

# In Detail
When running pre-commit hooks and also locally installing black via the instructions in `CONTRIBUTING.md` one could end up with different versions / settings leading to reformatting from the pre-commit hooks every commit. I also fixed the exclusions in the pre-commit configuration along the way, since it was throwing warnings:

```
 ▶ git commit -m "foo"
[WARNING] The 'exclude' field in hook 'flake8' is a regex, not a glob -- matching '/*' probably isn't what you want here
[WARNING] The 'exclude' field in hook 'black' is a regex, not a glob -- matching '/*' probably isn't what you want here
[WARNING] The 'exclude' field in hook 'isort' is a regex, not a glob -- matching '/*' probably isn't what you want here
[WARNING] The 'exclude' field in hook 'require-ascii' is a regex, not a glob -- matching '/*' probably isn't what you want here
[WARNING] The 'exclude' field in hook 'forbid-binary' is a regex, not a glob -- matching '/*' probably isn't what you want here
```