### PR TITLE
Fix missing dtype arg in _dtype_value_context 

### DIFF
--- a/linear_operator/settings.py
+++ b/linear_operator/settings.py
@@ -33,11 +33,11 @@ class _dtype_value_context:
             cls._global_half_value = half_value
 
     def __init__(self, float_value=None, double_value=None, half_value=None):
-        self._orig_float_value = self.__class__.value()
+        self._orig_float_value = self.__class__.value(dtype=torch.float)
         self._instance_float_value = float_value
-        self._orig_double_value = self.__class__.value()
+        self._orig_double_value = self.__class__.value(dtype=torch.double)
         self._instance_double_value = double_value
-        self._orig_half_value = self.__class__.value()
+        self._orig_half_value = self.__class__.value(dtype=torch.half)
         self._instance_half_value = half_value
 
     def __enter__(

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+import unittest
+import torch
+from linear_operator.settings import cholesky_jitter
+from linear_operator.test.base_test_case import BaseTestCase
+
+
+class TestSettings(BaseTestCase, unittest.TestCase):
+    def test_cholesky_jitter(self):
+        # Test value and defaults.
+        self.assertEqual(cholesky_jitter.value(dtype=torch.float), 1e-6)
+        self.assertEqual(
+            cholesky_jitter.value(dtype=torch.ones(1, dtype=torch.float)), 1e-6
+        )
+        self.assertEqual(cholesky_jitter.value(dtype=torch.double), 1e-8)
+        self.assertEqual(cholesky_jitter.value(dtype=torch.half), None)
+        with self.assertRaisesRegex(RuntimeError, "Unsupported dtype"):
+            cholesky_jitter.value(dtype=None)
+
+        # Test init/enter/exit/set_value.
+        with cholesky_jitter(float_value=0.1, double_value=0.01):
+            self.assertEqual(cholesky_jitter.value(dtype=torch.float), 0.1)
+            self.assertEqual(cholesky_jitter.value(dtype=torch.double), 0.01)
+        self.assertEqual(cholesky_jitter.value(dtype=torch.float), 1e-6)
+        self.assertEqual(cholesky_jitter.value(dtype=torch.double), 1e-8)


### PR DESCRIPTION
This was missing the `dtype` arg in `self.__class__.value(...)` call, leading to failures like https://github.com/pytorch/botorch/actions/runs/3990958264/jobs/6845226501.

Added (limited) units to help catch similar errors in the future.