### PR TITLE
Remove @cached decorator for TriangularLinearOperator.to_dense

### DIFF
--- a/linear_operator/operators/triangular_linear_operator.py
+++ b/linear_operator/operators/triangular_linear_operator.py
@@ -130,7 +130,6 @@ class TriangularLinearOperator(LinearOperator, _TriangularLinearOperatorBase):
         added_diag_lt = self._tensor.add_diagonal(added_diag)
         return self.__class__(added_diag_lt, upper=self.upper)
 
-    @cached
     def to_dense(self) -> Tensor:
         return self._tensor.to_dense()
 


### PR DESCRIPTION
This seems unnecessary and also causes issues with pickling: https://github.com/cornellius-gp/gpytorch/issues/2264#issue-1567345205