### PR TITLE
Format using ufmt, upgrade pre-commit config

### DIFF
--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: "3.8"
     - name: Install dependencies
       run: |
-        pip install flake8==4.0.1 flake8-print==4.0.0 pre-commit
+        pip install flake8==5.0.4 flake8-print==5.0.0 pre-commit
         pre-commit install
         pre-commit run seed-isort-config || true
     - name: Run linting

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v4.4.0
     hooks:
     -   id: check-byte-order-marker
     -   id: check-case-conflict
@@ -12,24 +12,19 @@ repos:
     -   id: trailing-whitespace
     -   id: debug-statements
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
     -   id: flake8
         args: [--config=setup.cfg]
         exclude: ^(examples/*)|(docs/*)
--   repo: https://github.com/ambv/black
-    rev: 22.3.0
+-   repo: https://github.com/omnilib/ufmt
+    rev: v2.0.0
     hooks:
-    -   id: black
+    -   id: ufmt
+        additional_dependencies:
+        - black == 22.3.0
+        - usort == 1.0.3
         exclude: ^(build/*)|(docs/*)|(examples/*)
-        args: [-l 120, --target-version=py37]
--   repo: https://github.com/pre-commit/mirrors-isort
-    rev: v5.10.1
-    hooks:
-    -   id: isort
-        language_version: python3
-        exclude: ^(build/*)|(docs/*)|(examples/*)
-        args: [-w120, -m3, --tc, --project=gpytorch]
 -   repo: https://github.com/jumanjihouse/pre-commit-hooks
     rev: 2.1.6
     hooks:
@@ -39,7 +34,7 @@ repos:
     -   id: forbid-binary
         exclude: ^(examples/*)|(test/examples/old_variational_strategy_model.pth)
 -   repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.13
+    rev: v1.3.1
     hooks:
     -   id: forbid-crlf
     -   id: forbid-tabs

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -17,8 +17,9 @@
 import os
 import sys
 import warnings
-import sphinx_rtd_theme  # noqa
 from typing import ForwardRef
+
+import sphinx_rtd_theme  # noqa
 
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "..", "..", "..")))

--- a/linear_operator/functions/__init__.py
+++ b/linear_operator/functions/__init__.py
@@ -106,7 +106,10 @@ def inv_quad(input: Anysor, inv_quad_rhs: torch.Tensor, reduce_inv_quad: bool = 
 
 
 def inv_quad_logdet(
-    input: Anysor, inv_quad_rhs: Optional[torch.Tensor] = None, logdet: bool = False, reduce_inv_quad: bool = True
+    input: Anysor,
+    inv_quad_rhs: Optional[torch.Tensor] = None,
+    logdet: bool = False,
+    reduce_inv_quad: bool = True,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     r"""
     Calls both :func:`inv_quad_logdet` and :func:`logdet` on a positive definite matrix (or batch) :math:`\mathbf A`.
@@ -128,7 +131,10 @@ def inv_quad_logdet(
 
 
 def pivoted_cholesky(
-    input: Anysor, rank: int, error_tol: Optional[float] = None, return_pivots: bool = False
+    input: Anysor,
+    rank: int,
+    error_tol: Optional[float] = None,
+    return_pivots: bool = False,
 ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
     r"""
     Performs a partial pivoted Cholesky factorization of a positive definite matrix (or batch of matrices).

--- a/linear_operator/functions/_pivoted_cholesky.py
+++ b/linear_operator/functions/_pivoted_cholesky.py
@@ -32,7 +32,13 @@ class PivotedCholesky(Function):
         max_iter = min(max_iter, matrix_shape[-1])
 
         # What we're returning
-        L = torch.zeros(*batch_shape, max_iter, matrix_shape[-1], dtype=matrix.dtype, device=matrix.device)
+        L = torch.zeros(
+            *batch_shape,
+            max_iter,
+            matrix_shape[-1],
+            dtype=matrix.dtype,
+            device=matrix.device,
+        )
         orig_error = torch.max(matrix_diag, dim=-1)[0]
         errors = torch.norm(matrix_diag, 1, dim=-1) / orig_error
 
@@ -76,7 +82,8 @@ class PivotedCholesky(Function):
                 if m > 0:
                     L_prev = L[..., :m, :].gather(-1, pi_i.unsqueeze(-2).repeat(*(1 for _ in batch_shape), m, 1))
                     update = L[..., :m, :].gather(
-                        -1, pi_m.view(*pi_m.shape, 1, 1).repeat(*(1 for _ in batch_shape), m, 1)
+                        -1,
+                        pi_m.view(*pi_m.shape, 1, 1).repeat(*(1 for _ in batch_shape), m, 1),
                     )
                     L_m_new -= torch.sum(update * L_prev, dim=-2)
 
@@ -120,10 +127,17 @@ class PivotedCholesky(Function):
 
             # Compute (Krows * L^{-T}) - the (pivoted) result of Pivoted Cholesky
             res_pivoted = torch.cat(
-                [L, torch.linalg.solve_triangular(L, Krows[..., m:, :].mT, upper=False).mT],
+                [
+                    L,
+                    torch.linalg.solve_triangular(L, Krows[..., m:, :].mT, upper=False).mT,
+                ],
                 dim=-2,
             )
-            res = apply_permutation(res_pivoted, left_permutation=_inverse_permutation, right_permutation=None)
+            res = apply_permutation(
+                res_pivoted,
+                left_permutation=_inverse_permutation,
+                right_permutation=None,
+            )
 
             # Now compute the backward pass of res
             res.backward(gradient=grad_output)

--- a/linear_operator/functions/_solve.py
+++ b/linear_operator/functions/_solve.py
@@ -101,7 +101,8 @@ class Solve(Function):
                     # To ensure that this term is symmetric, we concatenate the left and right solves together,
                     # and divide the result by 1/2
                     arg_grads = linear_op._bilinear_derivative(
-                        torch.cat([left_solves, right_solves], -1), torch.cat([right_solves, left_solves], -1).mul(-0.5)
+                        torch.cat([left_solves, right_solves], -1),
+                        torch.cat([right_solves, left_solves], -1).mul(-0.5),
                     )
                 if ctx.needs_input_grad[2]:
                     right_grad = left_solves
@@ -118,7 +119,8 @@ class Solve(Function):
                 if any(ctx.needs_input_grad[4:]):
                     # We do this concatenation to ensure that the gradient of linear_op is symmetric
                     arg_grads = linear_op._bilinear_derivative(
-                        torch.cat([left_solves, right_solves], -1), torch.cat([right_solves, left_solves], -1).mul(-0.5)
+                        torch.cat([left_solves, right_solves], -1),
+                        torch.cat([right_solves, left_solves], -1).mul(-0.5),
                     )
                 if ctx.needs_input_grad[3]:
                     right_grad = left_solves

--- a/linear_operator/operators/__init__.py
+++ b/linear_operator/operators/__init__.py
@@ -6,7 +6,7 @@ from .batch_repeat_linear_operator import BatchRepeatLinearOperator
 from .block_diag_linear_operator import BlockDiagLinearOperator
 from .block_interleaved_linear_operator import BlockInterleavedLinearOperator
 from .block_linear_operator import BlockLinearOperator
-from .cat_linear_operator import CatLinearOperator, cat
+from .cat_linear_operator import cat, CatLinearOperator
 from .chol_linear_operator import CholLinearOperator
 from .constant_mul_linear_operator import ConstantMulLinearOperator
 from .dense_linear_operator import DenseLinearOperator, to_linear_operator

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -380,7 +380,10 @@ class LinearOperator(ABC):
         return self.repeat(*batch_repeat, 1, 1)
 
     def _get_indices(
-        self, row_index: torch.LongTensor, col_index: torch.LongTensor, *batch_indices: Tuple[torch.LongTensor, ...]
+        self,
+        row_index: torch.LongTensor,
+        col_index: torch.LongTensor,
+        *batch_indices: Tuple[torch.LongTensor, ...],
     ) -> torch.Tensor:
         """
         This method selects elements from the LinearOperator based on tensor indices for each dimension.
@@ -758,7 +761,10 @@ class LinearOperator(ABC):
             if hasattr(self, "_default_preconditioner_cache"):
                 U, S, Vt = self._default_preconditioner_cache
             else:
-                precond_basis_size = min(linear_operator.settings.max_preconditioner_size.value(), self.size(-1))
+                precond_basis_size = min(
+                    linear_operator.settings.max_preconditioner_size.value(),
+                    self.size(-1),
+                )
                 random_basis = torch.randn(
                     self.batch_shape + torch.Size((self.size(-2), precond_basis_size)),
                     device=self.device,
@@ -1058,7 +1064,11 @@ class LinearOperator(ABC):
             updated_inv_root = TriangularLinearOperator(updated_inv_root)
 
         add_to_cache(new_linear_op, "root_decomposition", RootLinearOperator(updated_root))
-        add_to_cache(new_linear_op, "root_inv_decomposition", RootLinearOperator(updated_inv_root))
+        add_to_cache(
+            new_linear_op,
+            "root_inv_decomposition",
+            RootLinearOperator(updated_inv_root),
+        )
 
         return new_linear_op
 
@@ -1215,7 +1225,11 @@ class LinearOperator(ABC):
                 RootLinearOperator(to_linear_operator(new_inv_root)),
             )
 
-        add_to_cache(new_linear_op, "root_decomposition", RootLinearOperator(to_linear_operator(new_root)))
+        add_to_cache(
+            new_linear_op,
+            "root_decomposition",
+            RootLinearOperator(to_linear_operator(new_root)),
+        )
 
         return new_linear_op
 
@@ -1485,7 +1499,10 @@ class LinearOperator(ABC):
         """
         if len(sizes) == 1 and hasattr(sizes, "__iter__"):
             sizes = sizes[0]
-        if len(sizes) < 2 or tuple(sizes[-2:]) not in {tuple(self.matrix_shape), (-1, -1)}:
+        if len(sizes) < 2 or tuple(sizes[-2:]) not in {
+            tuple(self.matrix_shape),
+            (-1, -1),
+        }:
             raise RuntimeError(
                 "Invalid expand arguments {}. Currently, repeat only works to create repeated "
                 "batches of a 2D LinearOperator.".format(tuple(sizes))
@@ -1561,7 +1578,10 @@ class LinearOperator(ABC):
         return inv_quad_term
 
     def inv_quad_logdet(
-        self, inv_quad_rhs: Optional[torch.Tensor] = None, logdet: bool = False, reduce_inv_quad: bool = True
+        self,
+        inv_quad_rhs: Optional[torch.Tensor] = None,
+        logdet: bool = False,
+        reduce_inv_quad: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         r"""
         Calls both :func:`inv_quad_logdet` and :func:`logdet` on a positive
@@ -2215,7 +2235,11 @@ class LinearOperator(ABC):
 
     @_implements(torch.linalg.solve_triangular)
     def solve_triangular(
-        self, rhs: torch.Tensor, upper: bool, left: bool = True, unitriangular: bool = False
+        self,
+        rhs: torch.Tensor,
+        upper: bool,
+        left: bool = True,
+        unitriangular: bool = False,
     ) -> torch.Tensor:
         r"""
         Computes a triangular linear solve (w.r.t self = :math:`\mathbf A`) with right hand side :math:`\mathbf R`.
@@ -2392,7 +2416,9 @@ class LinearOperator(ABC):
         return self._svd()
 
     @_implements(torch.linalg.svd)
-    def _torch_linalg_svd(self) -> Tuple["LinearOperator", torch.Tensor, "LinearOperator"]:
+    def _torch_linalg_svd(
+        self,
+    ) -> Tuple["LinearOperator", torch.Tensor, "LinearOperator"]:
         r"""
         A version of self.svd() that matches the torch.linalg.svd API.
 
@@ -2761,7 +2787,11 @@ class LinearOperator(ABC):
 
     @classmethod
     def __torch_function__(
-        cls, func: Callable, types: Tuple[type, ...], args: Tuple[Any, ...] = (), kwargs: Dict[str, Any] = None
+        cls,
+        func: Callable,
+        types: Tuple[type, ...],
+        args: Tuple[Any, ...] = (),
+        kwargs: Dict[str, Any] = None,
     ) -> Any:
         if kwargs is None:
             kwargs = {}

--- a/linear_operator/operators/added_diag_linear_operator.py
+++ b/linear_operator/operators/added_diag_linear_operator.py
@@ -33,7 +33,10 @@ class AddedDiagLinearOperator(SumLinearOperator):
 
     def __init__(
         self,
-        *linear_ops: Union[Tuple[LinearOperator, DiagLinearOperator], Tuple[DiagLinearOperator, LinearOperator]],
+        *linear_ops: Union[
+            Tuple[LinearOperator, DiagLinearOperator],
+            Tuple[DiagLinearOperator, LinearOperator],
+        ],
         preconditioner_override: Optional[Callable] = None,
     ):
         linear_ops = list(linear_ops)

--- a/linear_operator/operators/batch_repeat_linear_operator.py
+++ b/linear_operator/operators/batch_repeat_linear_operator.py
@@ -66,7 +66,8 @@ class BatchRepeatLinearOperator(LinearOperator):
         padding_dims = torch.Size(tuple(1 for _ in range(max(len(batch_shape) + 2 - self.base_linear_op.dim(), 0))))
         current_batch_shape = padding_dims + self.base_linear_op.batch_shape
         return self.__class__(
-            self.base_linear_op, batch_repeat=self._compute_batch_repeat_size(current_batch_shape, batch_shape)
+            self.base_linear_op,
+            batch_repeat=self._compute_batch_repeat_size(current_batch_shape, batch_shape),
         )
 
     def _get_indices(self, row_index, col_index, *batch_indices):
@@ -229,7 +230,10 @@ class BatchRepeatLinearOperator(LinearOperator):
         return self.__class__(base_linear_op, batch_repeat=batch_repeat)
 
     def add_jitter(self, jitter_val=1e-3):
-        return self.__class__(self.base_linear_op.add_jitter(jitter_val=jitter_val), batch_repeat=self.batch_repeat)
+        return self.__class__(
+            self.base_linear_op.add_jitter(jitter_val=jitter_val),
+            batch_repeat=self.batch_repeat,
+        )
 
     def inv_quad_logdet(self, inv_quad_rhs=None, logdet=False, reduce_inv_quad=True):
         if not self.is_square:

--- a/linear_operator/operators/block_linear_operator.py
+++ b/linear_operator/operators/block_linear_operator.py
@@ -73,8 +73,16 @@ class BlockLinearOperator(LinearOperator):
         # Now we know that row_index and col_index
         num_blocks = self.num_blocks
         num_rows, num_cols = self.matrix_shape
-        row_start, row_end, row_step = row_index.start or 0, row_index.stop or num_rows, row_index.step
-        col_start, col_end, col_step = col_index.start or 0, col_index.stop or num_cols, col_index.step
+        row_start, row_end, row_step = (
+            row_index.start or 0,
+            row_index.stop or num_rows,
+            row_index.step,
+        )
+        col_start, col_end, col_step = (
+            col_index.start or 0,
+            col_index.stop or num_cols,
+            col_index.step,
+        )
 
         # If we have a step, it's too complicated - go with the base case
         if row_step is not None or col_step is not None:

--- a/linear_operator/operators/cat_linear_operator.py
+++ b/linear_operator/operators/cat_linear_operator.py
@@ -98,7 +98,11 @@ class CatLinearOperator(LinearOperator):
         self.cat_dim_cum_sizes = cat_dim_cum_sizes
         self.idx_to_tensor_idx = idx_to_tensor_idx
         self._shape = torch.Size(
-            (*rep_tensor.shape[:positive_dim], cat_dim_cum_sizes[-1].item(), *rep_tensor.shape[positive_dim + 1 :])
+            (
+                *rep_tensor.shape[:positive_dim],
+                cat_dim_cum_sizes[-1].item(),
+                *rep_tensor.shape[positive_dim + 1 :],
+            )
         )
 
     def _split_slice(self, slice_idx):
@@ -151,7 +155,10 @@ class CatLinearOperator(LinearOperator):
                 res.append(t[..., rows, cols].to(self.device))
             res = torch.cat(res, dim=-1)
         else:
-            res = torch.cat([t._diagonal().to(self.device) for t in self.linear_ops], dim=self.cat_dim + 1)
+            res = torch.cat(
+                [t._diagonal().to(self.device) for t in self.linear_ops],
+                dim=self.cat_dim + 1,
+            )
         return res
 
     def _expand_batch(self, batch_shape):
@@ -364,14 +371,18 @@ class CatLinearOperator(LinearOperator):
         else:
             new_dim = self.cat_dim
         return self.__class__(
-            *[t._transpose_nonbatch() for t in self.linear_ops], dim=new_dim, output_device=self.output_device
+            *[t._transpose_nonbatch() for t in self.linear_ops],
+            dim=new_dim,
+            output_device=self.output_device,
         )
 
     def _unsqueeze_batch(self, dim):
         cat_dim = self.dim() + self.cat_dim
         linear_ops = [linear_op._unsqueeze_batch(dim) for linear_op in self.linear_ops]
         res = self.__class__(
-            *linear_ops, dim=(cat_dim + 1 if dim <= cat_dim else cat_dim), output_device=self.output_device
+            *linear_ops,
+            dim=(cat_dim + 1 if dim <= cat_dim else cat_dim),
+            output_device=self.output_device,
         )
         return res
 

--- a/linear_operator/operators/chol_linear_operator.py
+++ b/linear_operator/operators/chol_linear_operator.py
@@ -10,7 +10,7 @@ import torch
 from ..utils.memoize import cached
 from ._linear_operator import LinearOperator
 from .root_linear_operator import RootLinearOperator
-from .triangular_linear_operator import TriangularLinearOperator, _TriangularLinearOperatorBase
+from .triangular_linear_operator import _TriangularLinearOperatorBase, TriangularLinearOperator
 
 
 class CholLinearOperator(RootLinearOperator):
@@ -92,7 +92,10 @@ class CholLinearOperator(RootLinearOperator):
         return inv_quad_term
 
     def inv_quad_logdet(
-        self, inv_quad_rhs: Optional[torch.Tensor] = None, logdet: bool = False, reduce_inv_quad: bool = True
+        self,
+        inv_quad_rhs: Optional[torch.Tensor] = None,
+        logdet: bool = False,
+        reduce_inv_quad: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         if not self.is_square:
             raise RuntimeError(

--- a/linear_operator/operators/constant_mul_linear_operator.py
+++ b/linear_operator/operators/constant_mul_linear_operator.py
@@ -109,7 +109,8 @@ class ConstantMulLinearOperator(LinearOperator):
 
     def _permute_batch(self, *dims):
         return self.__class__(
-            self.base_linear_op._permute_batch(*dims), self._constant.expand(self.batch_shape).permute(*dims)
+            self.base_linear_op._permute_batch(*dims),
+            self._constant.expand(self.batch_shape).permute(*dims),
         )
 
     def _bilinear_derivative(self, left_vecs, right_vecs):

--- a/linear_operator/operators/diag_linear_operator.py
+++ b/linear_operator/operators/diag_linear_operator.py
@@ -57,7 +57,10 @@ class DiagLinearOperator(TriangularLinearOperator):
         return self._diag
 
     def _get_indices(
-        self, row_index: torch.LongTensor, col_index: torch.LongTensor, *batch_indices: Tuple[torch.LongTensor, ...]
+        self,
+        row_index: torch.LongTensor,
+        col_index: torch.LongTensor,
+        *batch_indices: Tuple[torch.LongTensor, ...],
     ) -> Tensor:
         res = self._diag[(*batch_indices, row_index)]
         # If row and col index don't agree, then we have off diagonal elements
@@ -122,7 +125,10 @@ class DiagLinearOperator(TriangularLinearOperator):
         return self.__class__(self._diag.reciprocal())
 
     def inv_quad_logdet(
-        self, inv_quad_rhs: Optional[Tensor] = None, logdet: bool = False, reduce_inv_quad: bool = True
+        self,
+        inv_quad_rhs: Optional[Tensor] = None,
+        logdet: bool = False,
+        reduce_inv_quad: bool = True,
     ) -> Tuple[Tensor, Tensor]:
         # TODO: Use proper batching for inv_quad_rhs (prepand to shape rathern than append)
         if inv_quad_rhs is None:
@@ -188,7 +194,11 @@ class DiagLinearOperator(TriangularLinearOperator):
         return res
 
     def solve_triangular(
-        self, rhs: torch.Tensor, upper: bool, left: bool = True, unitriangular: bool = False
+        self,
+        rhs: torch.Tensor,
+        upper: bool,
+        left: bool = True,
+        unitriangular: bool = False,
     ) -> torch.Tensor:
         # upper or lower doesn't matter here, it's all the same
         if unitriangular:
@@ -332,7 +342,11 @@ class ConstantDiagLinearOperator(DiagLinearOperator):
         return super().matmul(other)
 
     def solve_triangular(
-        self, rhs: torch.Tensor, upper: bool, left: bool = True, unitriangular: bool = False
+        self,
+        rhs: torch.Tensor,
+        upper: bool,
+        left: bool = True,
+        unitriangular: bool = False,
     ) -> torch.Tensor:
         return rhs / self.diag_values
 

--- a/linear_operator/operators/identity_linear_operator.py
+++ b/linear_operator/operators/identity_linear_operator.py
@@ -33,7 +33,13 @@ class IdentityLinearOperator(ConstantDiagLinearOperator):
         device: Optional[torch.device] = None,
     ):
         one = torch.tensor(1.0, dtype=dtype, device=device)
-        LinearOperator.__init__(self, diag_shape=diag_shape, batch_shape=batch_shape, dtype=dtype, device=device)
+        LinearOperator.__init__(
+            self,
+            diag_shape=diag_shape,
+            batch_shape=batch_shape,
+            dtype=dtype,
+            device=device,
+        )
         self.diag_values = one.expand(torch.Size([*batch_shape, 1]))
         self.diag_shape = diag_shape
         self._batch_shape = batch_shape
@@ -68,7 +74,10 @@ class IdentityLinearOperator(ConstantDiagLinearOperator):
 
     def _expand_batch(self, batch_shape: torch.Size) -> LinearOperator:
         return IdentityLinearOperator(
-            diag_shape=self.diag_shape, batch_shape=batch_shape, dtype=self.dtype, device=self.device
+            diag_shape=self.diag_shape,
+            batch_shape=batch_shape,
+            dtype=self.dtype,
+            device=self.device,
         )
 
     def _getitem(
@@ -82,7 +91,10 @@ class IdentityLinearOperator(ConstantDiagLinearOperator):
             if len(batch_indices):
                 new_batch_shape = _compute_getitem_size(self, (*batch_indices, row_index, col_index))[:-2]
                 res = IdentityLinearOperator(
-                    diag_shape=self.diag_shape, batch_shape=new_batch_shape, dtype=self._dtype, device=self._device
+                    diag_shape=self.diag_shape,
+                    batch_shape=new_batch_shape,
+                    dtype=self._dtype,
+                    device=self._device,
                 )
                 return res
             else:
@@ -102,14 +114,20 @@ class IdentityLinearOperator(ConstantDiagLinearOperator):
     def _permute_batch(self, *dims: Tuple[int, ...]) -> LinearOperator:
         batch_shape = self.diag_values.permute(*dims, -1).shape[:-1]
         return IdentityLinearOperator(
-            diag_shape=self.diag_shape, batch_shape=batch_shape, dtype=self._dtype, device=self._device
+            diag_shape=self.diag_shape,
+            batch_shape=batch_shape,
+            dtype=self._dtype,
+            device=self._device,
         )
 
     def _prod_batch(self, dim: int) -> LinearOperator:
         batch_shape = list(self.batch_shape)
         del batch_shape[dim]
         return IdentityLinearOperator(
-            diag_shape=self.diag_shape, batch_shape=torch.Size(batch_shape), dtype=self.dtype, device=self.device
+            diag_shape=self.diag_shape,
+            batch_shape=torch.Size(batch_shape),
+            dtype=self.dtype,
+            device=self.device,
         )
 
     def _root_decomposition(self) -> LinearOperator:
@@ -143,7 +161,10 @@ class IdentityLinearOperator(ConstantDiagLinearOperator):
         batch_shape.insert(dim, 1)
         batch_shape = torch.Size(batch_shape)
         return IdentityLinearOperator(
-            diag_shape=self.diag_shape, batch_shape=batch_shape, dtype=self.dtype, device=self.device
+            diag_shape=self.diag_shape,
+            batch_shape=batch_shape,
+            dtype=self.dtype,
+            device=self.device,
         )
 
     def abs(self) -> LinearOperator:
@@ -156,7 +177,10 @@ class IdentityLinearOperator(ConstantDiagLinearOperator):
         return self
 
     def inv_quad_logdet(
-        self, inv_quad_rhs: Optional[torch.Tensor] = None, logdet: bool = False, reduce_inv_quad: bool = True
+        self,
+        inv_quad_rhs: Optional[torch.Tensor] = None,
+        logdet: bool = False,
+        reduce_inv_quad: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # TODO: Use proper batching for inv_quad_rhs (prepand to shape rathern than append)
         if inv_quad_rhs is None:
@@ -176,7 +200,11 @@ class IdentityLinearOperator(ConstantDiagLinearOperator):
 
     def log(self) -> LinearOperator:
         return ZeroLinearOperator(
-            *self._batch_shape, self.diag_shape, self.diag_shape, dtype=self._dtype, device=self._device
+            *self._batch_shape,
+            self.diag_shape,
+            self.diag_shape,
+            dtype=self._dtype,
+            device=self._device,
         )
 
     def matmul(self, other: Union[torch.Tensor, LinearOperator]) -> Union[torch.Tensor, LinearOperator]:
@@ -208,7 +236,10 @@ class IdentityLinearOperator(ConstantDiagLinearOperator):
 
     def type(self, dtype: torch.dtype) -> LinearOperator:
         return IdentityLinearOperator(
-            diag_shape=self.diag_shape, batch_shape=self.batch_shape, dtype=dtype, device=self.device
+            diag_shape=self.diag_shape,
+            batch_shape=self.batch_shape,
+            dtype=dtype,
+            device=self.device,
         )
 
     def zero_mean_mvn_samples(self, num_samples: int) -> torch.Tensor:

--- a/linear_operator/operators/interpolated_linear_operator.py
+++ b/linear_operator/operators/interpolated_linear_operator.py
@@ -18,7 +18,12 @@ from .root_linear_operator import RootLinearOperator
 
 class InterpolatedLinearOperator(LinearOperator):
     def _check_args(
-        self, base_linear_op, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
+        self,
+        base_linear_op,
+        left_interp_indices,
+        left_interp_values,
+        right_interp_indices,
+        right_interp_values,
     ):
         if left_interp_indices.size() != left_interp_values.size():
             return "Expected left_interp_indices ({}) to have the same size as left_interp_values ({})".format(
@@ -57,7 +62,9 @@ class InterpolatedLinearOperator(LinearOperator):
 
         if left_interp_values is None:
             left_interp_values = torch.ones(
-                left_interp_indices.size(), dtype=base_linear_op.dtype, device=base_linear_op.device
+                left_interp_indices.size(),
+                dtype=base_linear_op.dtype,
+                device=base_linear_op.device,
             )
 
         if right_interp_indices is None:
@@ -68,7 +75,9 @@ class InterpolatedLinearOperator(LinearOperator):
 
         if right_interp_values is None:
             right_interp_values = torch.ones(
-                right_interp_indices.size(), dtype=base_linear_op.dtype, device=base_linear_op.device
+                right_interp_indices.size(),
+                dtype=base_linear_op.dtype,
+                device=base_linear_op.device,
             )
 
         if left_interp_indices.shape[:-2] != base_linear_op.batch_shape:
@@ -82,7 +91,11 @@ class InterpolatedLinearOperator(LinearOperator):
                 )
 
         super(InterpolatedLinearOperator, self).__init__(
-            base_linear_op, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
+            base_linear_op,
+            left_interp_indices,
+            left_interp_values,
+            right_interp_indices,
+            right_interp_values,
         )
         self.base_linear_op = base_linear_op
         self.left_interp_indices = left_interp_indices
@@ -92,8 +105,16 @@ class InterpolatedLinearOperator(LinearOperator):
 
     def _approx_diagonal(self):
         base_diag_root = self.base_linear_op._diagonal().sqrt()
-        left_res = left_interp(self.left_interp_indices, self.left_interp_values, base_diag_root.unsqueeze(-1))
-        right_res = left_interp(self.right_interp_indices, self.right_interp_values, base_diag_root.unsqueeze(-1))
+        left_res = left_interp(
+            self.left_interp_indices,
+            self.left_interp_values,
+            base_diag_root.unsqueeze(-1),
+        )
+        right_res = left_interp(
+            self.right_interp_indices,
+            self.right_interp_values,
+            base_diag_root.unsqueeze(-1),
+        )
         res = left_res * right_res
         return res.squeeze(-1)
 
@@ -102,10 +123,14 @@ class InterpolatedLinearOperator(LinearOperator):
             self.base_linear_op.root, DenseLinearOperator
         ):
             left_interp_vals = left_interp(
-                self.left_interp_indices, self.left_interp_values, self.base_linear_op.root.to_dense()
+                self.left_interp_indices,
+                self.left_interp_values,
+                self.base_linear_op.root.to_dense(),
             )
             right_interp_vals = left_interp(
-                self.right_interp_indices, self.right_interp_values, self.base_linear_op.root.to_dense()
+                self.right_interp_indices,
+                self.right_interp_values,
+                self.base_linear_op.root.to_dense(),
             )
             return (left_interp_vals * right_interp_vals).sum(-1)
         else:
@@ -341,7 +366,9 @@ class InterpolatedLinearOperator(LinearOperator):
                 return self._sparse_left_interp_t_memo
 
         left_interp_t = sparse.make_sparse_from_indices_and_values(
-            left_interp_indices_tensor, left_interp_values_tensor, self.base_linear_op.size()[-2]
+            left_interp_indices_tensor,
+            left_interp_values_tensor,
+            self.base_linear_op.size()[-2],
         )
         self._left_interp_indices_memo = left_interp_indices_tensor
         self._left_interp_values_memo = left_interp_values_tensor
@@ -356,7 +383,9 @@ class InterpolatedLinearOperator(LinearOperator):
                 return self._sparse_right_interp_t_memo
 
         right_interp_t = sparse.make_sparse_from_indices_and_values(
-            right_interp_indices_tensor, right_interp_values_tensor, self.base_linear_op.size()[-1]
+            right_interp_indices_tensor,
+            right_interp_values_tensor,
+            self.base_linear_op.size()[-1],
         )
         self._right_interp_indices_memo = right_interp_indices_tensor
         self._right_interp_values_memo = right_interp_values_tensor
@@ -381,8 +410,16 @@ class InterpolatedLinearOperator(LinearOperator):
 
         # Rearrange the indices and values
         permute_order = (*range(0, dim), *range(dim + 1, self.dim()), dim)
-        left_shape = (*left_interp_indices.shape[:dim], *left_interp_indices.shape[dim + 1 : -1], -1)
-        right_shape = (*right_interp_indices.shape[:dim], *right_interp_indices.shape[dim + 1 : -1], -1)
+        left_shape = (
+            *left_interp_indices.shape[:dim],
+            *left_interp_indices.shape[dim + 1 : -1],
+            -1,
+        )
+        right_shape = (
+            *right_interp_indices.shape[:dim],
+            *right_interp_indices.shape[dim + 1 : -1],
+            -1,
+        )
         left_interp_indices = left_interp_indices.permute(permute_order).reshape(left_shape)
         left_interp_values = left_interp_values.permute(permute_order).reshape(left_shape)
         right_interp_indices = right_interp_indices.permute(permute_order).reshape(right_shape)
@@ -395,7 +432,11 @@ class InterpolatedLinearOperator(LinearOperator):
 
         # Finally! We have an interpolated lazy tensor again
         return InterpolatedLinearOperator(
-            block_diag, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
+            block_diag,
+            left_interp_indices,
+            left_interp_values,
+            right_interp_indices,
+            right_interp_values,
         )
 
     def double(self, device_id=None):

--- a/linear_operator/operators/kronecker_product_linear_operator.py
+++ b/linear_operator/operators/kronecker_product_linear_operator.py
@@ -13,7 +13,7 @@ from ..utils.memoize import cached
 from ._linear_operator import LinearOperator
 from .dense_linear_operator import to_linear_operator
 from .diag_linear_operator import ConstantDiagLinearOperator, DiagLinearOperator
-from .triangular_linear_operator import TriangularLinearOperator, _TriangularLinearOperatorBase
+from .triangular_linear_operator import _TriangularLinearOperatorBase, TriangularLinearOperator
 
 
 def _kron_diag(*lts) -> Tensor:
@@ -306,7 +306,10 @@ class KroneckerProductLinearOperator(LinearOperator):
         return res
 
     def _transpose_nonbatch(self):
-        return self.__class__(*(linear_op._transpose_nonbatch() for linear_op in self.linear_ops), **self._kwargs)
+        return self.__class__(
+            *(linear_op._transpose_nonbatch() for linear_op in self.linear_ops),
+            **self._kwargs,
+        )
 
 
 class KroneckerProductTriangularLinearOperator(KroneckerProductLinearOperator, _TriangularLinearOperatorBase):

--- a/linear_operator/operators/linear_operator_representation_tree.py
+++ b/linear_operator/operators/linear_operator_representation_tree.py
@@ -11,7 +11,12 @@ class LinearOperatorRepresentationTree(object):
         for arg in linear_op._args:
             if hasattr(arg, "representation") and callable(arg.representation):  # Is it a lazy tensor?
                 representation_size = len(arg.representation())
-                self.children.append((slice(counter, counter + representation_size, None), arg.representation_tree()))
+                self.children.append(
+                    (
+                        slice(counter, counter + representation_size, None),
+                        arg.representation_tree(),
+                    )
+                )
                 counter += representation_size
             else:
                 self.children.append((counter, None))

--- a/linear_operator/operators/low_rank_root_added_diag_linear_operator.py
+++ b/linear_operator/operators/low_rank_root_added_diag_linear_operator.py
@@ -46,7 +46,8 @@ class LowRankRootAddedDiagLinearOperator(AddedDiagLinearOperator):
             res = super()._mul_constant(constant)
         else:
             res = AddedDiagLinearOperator(
-                self._linear_op._mul_constant(constant), self._diag_tensor._mul_constant(constant)
+                self._linear_op._mul_constant(constant),
+                self._diag_tensor._mul_constant(constant),
             )
         return res
 

--- a/linear_operator/operators/matmul_linear_operator.py
+++ b/linear_operator/operators/matmul_linear_operator.py
@@ -43,7 +43,8 @@ class MatmulLinearOperator(LinearOperator):
 
     def _expand_batch(self, batch_shape):
         return self.__class__(
-            self.left_linear_op._expand_batch(batch_shape), self.right_linear_op._expand_batch(batch_shape)
+            self.left_linear_op._expand_batch(batch_shape),
+            self.right_linear_op._expand_batch(batch_shape),
         )
 
     def _get_indices(self, row_index, col_index, *batch_indices):
@@ -107,13 +108,19 @@ class MatmulLinearOperator(LinearOperator):
         return left_grad + right_grad
 
     def _permute_batch(self, *dims):
-        return self.__class__(self.left_linear_op._permute_batch(*dims), self.right_linear_op._permute_batch(*dims))
+        return self.__class__(
+            self.left_linear_op._permute_batch(*dims),
+            self.right_linear_op._permute_batch(*dims),
+        )
 
     def _size(self):
         return _matmul_broadcast_shape(self.left_linear_op.shape, self.right_linear_op.shape)
 
     def _transpose_nonbatch(self, *args):
-        return self.__class__(self.right_linear_op._transpose_nonbatch(), self.left_linear_op._transpose_nonbatch())
+        return self.__class__(
+            self.right_linear_op._transpose_nonbatch(),
+            self.left_linear_op._transpose_nonbatch(),
+        )
 
     @cached
     def to_dense(self):

--- a/linear_operator/operators/mul_linear_operator.py
+++ b/linear_operator/operators/mul_linear_operator.py
@@ -120,7 +120,8 @@ class MulLinearOperator(LinearOperator):
 
     def _expand_batch(self, batch_shape):
         return self.__class__(
-            self.left_linear_op._expand_batch(batch_shape), self.right_linear_op._expand_batch(batch_shape)
+            self.left_linear_op._expand_batch(batch_shape),
+            self.right_linear_op._expand_batch(batch_shape),
         )
 
     @cached

--- a/linear_operator/operators/triangular_linear_operator.py
+++ b/linear_operator/operators/triangular_linear_operator.py
@@ -86,7 +86,10 @@ class TriangularLinearOperator(LinearOperator, _TriangularLinearOperatorBase):
         return self.__class__(tensor=self._tensor._expand_batch(batch_shape), upper=self.upper)
 
     def _get_indices(
-        self, row_index: torch.LongTensor, col_index: torch.LongTensor, *batch_indices: Tuple[torch.LongTensor, ...]
+        self,
+        row_index: torch.LongTensor,
+        col_index: torch.LongTensor,
+        *batch_indices: Tuple[torch.LongTensor, ...],
     ) -> Tensor:
         return self._tensor._get_indices(row_index, col_index, *batch_indices)
 
@@ -194,7 +197,11 @@ class TriangularLinearOperator(LinearOperator, _TriangularLinearOperatorBase):
         return res
 
     def solve_triangular(
-        self, rhs: torch.Tensor, upper: bool, left: bool = True, unitriangular: bool = False
+        self,
+        rhs: torch.Tensor,
+        upper: bool,
+        left: bool = True,
+        unitriangular: bool = False,
     ) -> torch.Tensor:
         if upper != self.upper:
             raise RuntimeError(

--- a/linear_operator/operators/zero_linear_operator.py
+++ b/linear_operator/operators/zero_linear_operator.py
@@ -21,7 +21,10 @@ class ZeroLinearOperator(LinearOperator):
     """
 
     def __init__(
-        self, *sizes: Tuple[int, ...], dtype: Optional[torch.dtype] = None, device: Optional[torch.device] = None
+        self,
+        *sizes: Tuple[int, ...],
+        dtype: Optional[torch.dtype] = None,
+        device: Optional[torch.device] = None,
     ):
         super(ZeroLinearOperator, self).__init__(*sizes)
         self.sizes = list(sizes)
@@ -48,7 +51,10 @@ class ZeroLinearOperator(LinearOperator):
         return self.__class__(*batch_shape, *self.sizes[-2:], dtype=self._dtype, device=self._device)
 
     def _get_indices(
-        self, row_index: torch.LongTensor, col_index: torch.LongTensor, *batch_indices: Tuple[torch.LongTensor, ...]
+        self,
+        row_index: torch.LongTensor,
+        col_index: torch.LongTensor,
+        *batch_indices: Tuple[torch.LongTensor, ...],
     ) -> torch.Tensor:
         new_size = _compute_getitem_size(self, batch_indices + (row_index, col_index))
         return ZeroLinearOperator(*new_size)
@@ -166,7 +172,10 @@ class ZeroLinearOperator(LinearOperator):
         raise RuntimeError("ZeroLinearOperators are not invertible!")
 
     def inv_quad_logdet(
-        self, inv_quad_rhs: Optional[torch.Tensor] = None, logdet: bool = False, reduce_inv_quad: bool = True
+        self,
+        inv_quad_rhs: Optional[torch.Tensor] = None,
+        logdet: bool = False,
+        reduce_inv_quad: bool = True,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         raise RuntimeError("ZeroLinearOperators are not invertible!")
 

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -249,14 +249,20 @@ class RectangularLinearOperatorTestCase(BaseTestCase):
                     torch.tensor([0, 1, 0, 2]),
                     slice(None, None, None),
                 )
-                res, actual = linear_operator.to_dense(linear_op[index]), evaluated[index]
+                res, actual = (
+                    linear_operator.to_dense(linear_op[index]),
+                    evaluated[index],
+                )
                 self.assertAllClose(res, actual)
                 index = (
                     *batch_index,
                     slice(None, None, None),
                     torch.tensor([0, 1, 2, 1]),
                 )
-                res, actual = linear_operator.to_dense(linear_op[index]), evaluated[index]
+                res, actual = (
+                    linear_operator.to_dense(linear_op[index]),
+                    evaluated[index],
+                )
                 self.assertAllClose(res, actual)
                 index = (*batch_index, slice(None, None, None), slice(None, None, None))
                 res, actual = linear_op[index].to_dense(), evaluated[index]
@@ -278,10 +284,17 @@ class RectangularLinearOperatorTestCase(BaseTestCase):
 
         # Non-batch case
         if linear_op.ndimension() == 2:
-            index = (torch.tensor([0, 0, 1, 2]).unsqueeze(-1), torch.tensor([0, 1, 0, 2]).unsqueeze(-2))
+            index = (
+                torch.tensor([0, 0, 1, 2]).unsqueeze(-1),
+                torch.tensor([0, 1, 0, 2]).unsqueeze(-2),
+            )
             res, actual = linear_op[index], evaluated[index]
             self.assertAllClose(res, actual)
-            index = (Ellipsis, torch.tensor([0, 0, 1, 2]).unsqueeze(-2), torch.tensor([0, 1, 0, 2]).unsqueeze(-1))
+            index = (
+                Ellipsis,
+                torch.tensor([0, 0, 1, 2]).unsqueeze(-2),
+                torch.tensor([0, 1, 0, 2]).unsqueeze(-1),
+            )
             res, actual = linear_op[index], evaluated[index]
             self.assertAllClose(res, actual)
 
@@ -298,7 +311,10 @@ class RectangularLinearOperatorTestCase(BaseTestCase):
                 )
                 res, actual = linear_op[index], evaluated[index]
                 self.assertAllClose(res, actual)
-                res, actual = linear_operator.to_dense(linear_op[index]), evaluated[index]
+                res, actual = (
+                    linear_operator.to_dense(linear_op[index]),
+                    evaluated[index],
+                )
                 self.assertAllClose(res, actual)
                 index = (*batch_index, slice(None, None, None), slice(None, None, None))
                 res, actual = linear_op[index].to_dense(), evaluated[index]
@@ -306,19 +322,35 @@ class RectangularLinearOperatorTestCase(BaseTestCase):
 
             # Ellipsis
             res = linear_op.__getitem__(
-                (Ellipsis, torch.tensor([0, 1, 0]).view(-1, 1, 1), torch.tensor([1, 2, 0, 1]).view(1, 1, -1))
+                (
+                    Ellipsis,
+                    torch.tensor([0, 1, 0]).view(-1, 1, 1),
+                    torch.tensor([1, 2, 0, 1]).view(1, 1, -1),
+                )
             )
             actual = evaluated.__getitem__(
-                (Ellipsis, torch.tensor([0, 1, 0]).view(-1, 1, 1), torch.tensor([1, 2, 0, 1]).view(1, 1, -1))
+                (
+                    Ellipsis,
+                    torch.tensor([0, 1, 0]).view(-1, 1, 1),
+                    torch.tensor([1, 2, 0, 1]).view(1, 1, -1),
+                )
             )
             self.assertAllClose(res, actual)
             res = linear_operator.to_dense(
                 linear_op.__getitem__(
-                    (torch.tensor([0, 1, 0]).view(1, -1), Ellipsis, torch.tensor([1, 2, 0, 1]).view(-1, 1))
+                    (
+                        torch.tensor([0, 1, 0]).view(1, -1),
+                        Ellipsis,
+                        torch.tensor([1, 2, 0, 1]).view(-1, 1),
+                    )
                 )
             )
             actual = evaluated.__getitem__(
-                (torch.tensor([0, 1, 0]).view(1, -1), Ellipsis, torch.tensor([1, 2, 0, 1]).view(-1, 1))
+                (
+                    torch.tensor([0, 1, 0]).view(1, -1),
+                    Ellipsis,
+                    torch.tensor([1, 2, 0, 1]).view(-1, 1),
+                )
             )
             self.assertAllClose(res, actual)
 
@@ -508,7 +540,9 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
                         4
                     ), linear_operator.settings.max_preconditioner_size(2):
                         res_inv_quad, res_logdet = linear_op.inv_quad_logdet(
-                            inv_quad_rhs=vecs, logdet=True, reduce_inv_quad=reduce_inv_quad
+                            inv_quad_rhs=vecs,
+                            logdet=True,
+                            reduce_inv_quad=reduce_inv_quad,
                         )
 
             actual_inv_quad = evaluated.inverse().matmul(vecs_copy).mul(vecs_copy).sum(-2)

--- a/linear_operator/utils/contour_integral_quad.py
+++ b/linear_operator/utils/contour_integral_quad.py
@@ -55,7 +55,12 @@ def contour_integral_quad(
         # Determine if init_vecs has extra_dimensions
         num_extra_dims = max(0, rhs.dim() - linear_op.dim())
         lanczos_init = rhs.__getitem__(
-            (*([0] * num_extra_dims), Ellipsis, slice(None, None, None), slice(None, 1, None))
+            (
+                *([0] * num_extra_dims),
+                Ellipsis,
+                slice(None, None, None),
+                slice(None, 1, None),
+            )
         ).expand(*linear_op.shape[:-1], 1)
         with warnings.catch_warnings(), torch.no_grad():
             warnings.simplefilter("ignore", NumericalWarning)  # Supress CG stopping warning
@@ -134,7 +139,13 @@ def contour_integral_quad(
     # Compute the solves at the given shifts
     # Do one more matmul if we don't want to include the inverse
     with torch.no_grad():
-        solves = minres(lambda v: linear_op._matmul(v), rhs, value=-1, shifts=shifts, preconditioner=preconditioner)
+        solves = minres(
+            lambda v: linear_op._matmul(v),
+            rhs,
+            value=-1,
+            shifts=shifts,
+            preconditioner=preconditioner,
+        )
     no_shift_solves = solves[0]
     solves = solves[1:]
     if not inverse:

--- a/linear_operator/utils/deprecation.py
+++ b/linear_operator/utils/deprecation.py
@@ -32,7 +32,10 @@ def _deprecated_function_for(old_function_name, function):
 def _deprecate_kwarg(kwargs, old_kw, new_kw, new_kw_value):
     old_kwarg = kwargs.get(old_kw)
     if old_kwarg is not None:
-        warnings.warn("The `{}` argument is deprecated. Use `{}` instead.".format(old_kw, new_kw), DeprecationWarning)
+        warnings.warn(
+            "The `{}` argument is deprecated. Use `{}` instead.".format(old_kw, new_kw),
+            DeprecationWarning,
+        )
         if new_kw_value is not None:
             raise ValueError("Cannot set both `{}` and `{}`".format(old_kw, new_kw))
         return old_kwarg
@@ -42,7 +45,10 @@ def _deprecate_kwarg(kwargs, old_kw, new_kw, new_kw_value):
 def _deprecate_kwarg_with_transform(kwargs, old_kw, new_kw, new_kw_value, transform):
     old_kwarg = kwargs.get(old_kw)
     if old_kwarg is not None:
-        warnings.warn("The `{}` argument is deprecated. Use `{}` instead.".format(old_kw, new_kw), DeprecationWarning)
+        warnings.warn(
+            "The `{}` argument is deprecated. Use `{}` instead.".format(old_kw, new_kw),
+            DeprecationWarning,
+        )
         return transform(old_kwarg)
     return new_kw_value
 

--- a/linear_operator/utils/getitem.py
+++ b/linear_operator/utils/getitem.py
@@ -14,7 +14,8 @@ _noop_index = slice(None, None, None)
 
 
 def _compute_getitem_size(
-    obj: Union[torch.Tensor, "LinearOperator"], indices: Tuple[Union[slice, torch.LongTensor, int], ...]  # noqa F811
+    obj: Union[torch.Tensor, "LinearOperator"],  # noqa F821
+    indices: Tuple[Union[slice, torch.LongTensor, int], ...],  # noqa F811
 ) -> torch.Size:
     """
     Given an object and a tuple of indices, computes the final size of the
@@ -92,7 +93,8 @@ def _compute_getitem_size(
 
 
 def _convert_indices_to_tensors(
-    obj: Union[torch.Tensor, "LinearOperator"], indices: Tuple[Union[slice, torch.LongTensor, int], ...]  # noqa F811
+    obj: Union[torch.Tensor, "LinearOperator"],  # noqa F821
+    indices: Tuple[Union[slice, torch.LongTensor, int], ...],  # noqa F811
 ) -> Tuple[torch.LongTensor, ...]:
     """
     Given an index made up of tensors/slices/ints, returns a tensor-only index that has the

--- a/linear_operator/utils/interpolation.py
+++ b/linear_operator/utils/interpolation.py
@@ -58,7 +58,9 @@ def left_t_interp(interp_indices, interp_values, rhs, output_dim):
     column_indices = column_indices.repeat(batch_size, 1)
     summing_matrix_indices = torch.stack([batch_indices.view(-1), interp_indices.view(-1), column_indices.view(-1)], 0)
     summing_matrix_values = torch.ones(
-        batch_size * num_data * num_interp, dtype=interp_values.dtype, device=interp_values.device
+        batch_size * num_data * num_interp,
+        dtype=interp_values.dtype,
+        device=interp_values.device,
     )
     size = torch.Size((batch_size, output_dim, num_data * num_interp))
     type_name = summing_matrix_values.type().split(".")[-1]  # e.g. FloatTensor

--- a/linear_operator/utils/lanczos.py
+++ b/linear_operator/utils/lanczos.py
@@ -65,7 +65,14 @@ def lanczos_tridiag(
     # q_mat - batch version of Q - orthogonal matrix of decomp
     # alpha - batch version main diagonal of T
     # beta - batch version of off diagonal of T
-    q_mat = torch.zeros(num_iter, *batch_shape, matrix_shape[-1], num_init_vecs, dtype=dtype, device=device)
+    q_mat = torch.zeros(
+        num_iter,
+        *batch_shape,
+        matrix_shape[-1],
+        num_init_vecs,
+        dtype=dtype,
+        device=device,
+    )
     t_mat = torch.zeros(num_iter, num_iter, *batch_shape, num_init_vecs, dtype=dtype, device=device)
 
     # Begin algorithm

--- a/linear_operator/utils/linear_cg.py
+++ b/linear_operator/utils/linear_cg.py
@@ -15,7 +15,16 @@ def _default_preconditioner(x):
 
 @torch.jit.script
 def _jit_linear_cg_updates(
-    result, alpha, residual_inner_prod, eps, beta, residual, precond_residual, mul_storage, is_zero, curr_conjugate_vec
+    result,
+    alpha,
+    residual_inner_prod,
+    eps,
+    beta,
+    residual,
+    precond_residual,
+    mul_storage,
+    is_zero,
+    curr_conjugate_vec,
 ):
     # # Update result
     # # result_{k} = result_{k-1} + alpha_{k} p_vec_{k-1}
@@ -213,7 +222,12 @@ def linear_cg(
     # Define tridiagonal matrices, if applicable
     if n_tridiag:
         t_mat = torch.zeros(
-            n_tridiag_iter, n_tridiag_iter, *batch_shape, n_tridiag, dtype=alpha.dtype, device=alpha.device
+            n_tridiag_iter,
+            n_tridiag_iter,
+            *batch_shape,
+            n_tridiag,
+            dtype=alpha.dtype,
+            device=alpha.device,
         )
         alpha_tridiag_is_zero = torch.empty(*batch_shape, n_tridiag, dtype=bool_compat, device=t_mat.device)
         alpha_reciprocal = torch.empty(*batch_shape, n_tridiag, dtype=t_mat.dtype, device=t_mat.device)
@@ -336,6 +350,9 @@ def linear_cg(
 
     if n_tridiag:
         t_mat = t_mat[: last_tridiag_iter + 1, : last_tridiag_iter + 1]
-        return result, t_mat.permute(-1, *range(2, 2 + len(batch_shape)), 0, 1).contiguous()
+        return (
+            result,
+            t_mat.permute(-1, *range(2, 2 + len(batch_shape)), 0, 1).contiguous(),
+        )
     else:
         return result

--- a/linear_operator/utils/minres.py
+++ b/linear_operator/utils/minres.py
@@ -6,7 +6,15 @@ from .. import settings
 from .broadcasting import _pad_with_singletons
 
 
-def minres(matmul_closure, rhs, eps=1e-25, shifts=None, value=None, max_iter=None, preconditioner=None):
+def minres(
+    matmul_closure,
+    rhs,
+    eps=1e-25,
+    shifts=None,
+    value=None,
+    max_iter=None,
+    preconditioner=None,
+):
     r"""
     Perform MINRES to find solutions to :math:`(\mathbf K + \alpha \sigma \mathbf I) \mathbf x = \mathbf b`.
     Will find solutions for multiple shifts :math:`\sigma` at the same time.
@@ -103,7 +111,12 @@ def minres(matmul_closure, rhs, eps=1e-25, shifts=None, value=None, max_iter=Non
     scale_curr = torch.empty_like(scale_prev)
 
     # Terms for checking for convergence
-    solution_norm = torch.zeros(*solution.shape[:-2], solution.size(-1), dtype=solution.dtype, device=solution.device)
+    solution_norm = torch.zeros(
+        *solution.shape[:-2],
+        solution.size(-1),
+        dtype=solution.dtype,
+        device=solution.device,
+    )
     search_update_norm = torch.zeros_like(solution_norm)
 
     # Maybe log
@@ -183,7 +196,11 @@ def minres(matmul_closure, rhs, eps=1e-25, shifts=None, value=None, max_iter=Non
         cos_prev2, cos_prev1, cos_curr = cos_prev1, cos_curr, cos_prev2
         sin_prev2, sin_prev1, sin_curr = sin_prev1, sin_curr, sin_prev2
         # Search vector terms)
-        search_prev2, search_prev1, search_curr = search_prev1, search_curr, search_prev2
+        search_prev2, search_prev1, search_curr = (
+            search_prev1,
+            search_curr,
+            search_prev2,
+        )
         scale_prev, scale_curr = scale_curr, scale_prev
 
     # For rhs-s that are close to zero, set them to zero

--- a/linear_operator/utils/permutation.py
+++ b/linear_operator/utils/permutation.py
@@ -76,7 +76,15 @@ def apply_permutation(
         right_permutation = torch.arange(matrix.size(-1), device=matrix.device)
 
     # Apply permutations
-    return to_dense(matrix.__getitem__((*batch_idx, left_permutation.unsqueeze(-1), right_permutation.unsqueeze(-2))))
+    return to_dense(
+        matrix.__getitem__(
+            (
+                *batch_idx,
+                left_permutation.unsqueeze(-1),
+                right_permutation.unsqueeze(-2),
+            )
+        )
+    )
 
 
 def inverse_permutation(permutation):

--- a/linear_operator/utils/sparse.py
+++ b/linear_operator/utils/sparse.py
@@ -33,7 +33,10 @@ def make_sparse_from_indices_and_values(interp_indices, interp_values, num_rows)
         batch_tensor = torch.arange(0, batch_size, dtype=torch.long, device=interp_values.device)
         batch_tensor = (
             batch_tensor.unsqueeze_(1)
-            .repeat(batch_shape[:i].numel(), batch_shape[i + 1 :].numel() * n_target_points * n_coefficients)
+            .repeat(
+                batch_shape[:i].numel(),
+                batch_shape[i + 1 :].numel() * n_target_points * n_coefficients,
+            )
             .view(-1)
         )
         batch_tensors.append(batch_tensor)
@@ -158,7 +161,10 @@ def sparse_getitem(sparse, idxs):
             mask = indices[i].eq(idx)
             if torch.any(mask):
                 new_indices = torch.zeros(
-                    indices.size(0) - 1, torch.sum(mask), dtype=indices.dtype, device=indices.device
+                    indices.size(0) - 1,
+                    torch.sum(mask),
+                    dtype=indices.dtype,
+                    device=indices.device,
                 )
                 for j in range(indices.size(0)):
                     if i > j:
@@ -181,7 +187,12 @@ def sparse_getitem(sparse, idxs):
                 raise RuntimeError("Slicing with step is not supported")
             mask = indices[i].lt(stop) & indices[i].ge(start)
             if torch.any(mask):
-                new_indices = torch.zeros(indices.size(0), torch.sum(mask), dtype=indices.dtype, device=indices.device)
+                new_indices = torch.zeros(
+                    indices.size(0),
+                    torch.sum(mask),
+                    dtype=indices.dtype,
+                    device=indices.device,
+                )
                 for j in range(indices.size(0)):
                     new_indices[j].copy_(indices[j][mask])
                 new_indices[i].sub_(start)
@@ -207,7 +218,12 @@ def sparse_repeat(sparse, *repeat_sizes):
         new_indices = sparse._indices()
         new_indices = torch.cat(
             [
-                torch.zeros(num_new_dims, new_indices.size(1), dtype=new_indices.dtype, device=new_indices.device),
+                torch.zeros(
+                    num_new_dims,
+                    new_indices.size(1),
+                    dtype=new_indices.dtype,
+                    device=new_indices.device,
+                ),
                 new_indices,
             ],
             0,
@@ -230,7 +246,13 @@ def sparse_repeat(sparse, *repeat_sizes):
             sparse = torch.sparse_coo_tensor(
                 new_indices,
                 sparse._values().repeat(repeat_size),
-                torch.Size((*sparse.shape[:i], repeat_size * sparse.size(i), *sparse.shape[i + 1 :])),
+                torch.Size(
+                    (
+                        *sparse.shape[:i],
+                        repeat_size * sparse.size(i),
+                        *sparse.shape[i + 1 :],
+                    )
+                ),
                 dtype=sparse.dtype,
                 device=sparse.device,
             )

--- a/linear_operator/utils/toeplitz.py
+++ b/linear_operator/utils/toeplitz.py
@@ -38,7 +38,10 @@ def toeplitz(toeplitz_column, toeplitz_row):
         return toeplitz_column.view(1, 1)
 
     res = torch.empty(
-        len(toeplitz_column), len(toeplitz_column), dtype=toeplitz_column.dtype, device=toeplitz_column.device
+        len(toeplitz_column),
+        len(toeplitz_column),
+        dtype=toeplitz_column.dtype,
+        device=toeplitz_column.device,
     )
     for i, val in enumerate(toeplitz_column):
         for j in range(len(toeplitz_column) - i):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,12 @@
 requires = ["setuptools", "setuptools-scm", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.black]
+line-length = 120
+
+[tool.usort.known]
+first_party = ["linear_operator"]
+
 [tool.setuptools_scm]
 local_scheme = "node-and-date"
 write_to = "./linear_operator/version.py"

--- a/setup.py
+++ b/setup.py
@@ -68,13 +68,16 @@ setup(
         "Source": "https://github.com/cornellius-gp/linear_operator/",
     },
     license="MIT",
-    classifiers=["Development Status :: 2 - Pre-Alpha", "Programming Language :: Python :: 3"],
+    classifiers=[
+        "Development Status :: 2 - Pre-Alpha",
+        "Programming Language :: Python :: 3",
+    ],
     packages=find_packages(exclude=["test", "test.*"]),
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require={
-        "dev": ["black", "twine", "pre-commit"],
-        "test": ["flake8==4.0.1", "flake8-print==4.0.0"],
+        "dev": ["ufmt", "twine", "pre-commit"],
+        "test": ["flake8==5.0.4", "flake8-print==5.0.0"],
     },
     test_suite="test",
 )

--- a/test/functions/test_dsmm.py
+++ b/test/functions/test_dsmm.py
@@ -19,7 +19,10 @@ class TestDSMM(unittest.TestCase):
         self.assertLess(torch.norm(res - actual), 1e-5)
 
     def test_forward_batch(self):
-        i = torch.tensor([[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]], dtype=torch.long)
+        i = torch.tensor(
+            [[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]],
+            dtype=torch.long,
+        )
         v = torch.tensor([3, 4, 5, 6, 7, 8], dtype=torch.float)
         sparse = torch.sparse.FloatTensor(i, v, torch.Size([2, 2, 3]))
         dense = torch.randn(2, 3, 3)
@@ -30,7 +33,13 @@ class TestDSMM(unittest.TestCase):
 
     def test_forward_multi_batch(self):
         i = torch.tensor(
-            [[0, 1, 1, 0, 0, 1], [0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]], dtype=torch.long
+            [
+                [0, 1, 1, 0, 0, 1],
+                [0, 0, 0, 1, 1, 1],
+                [0, 1, 1, 0, 1, 1],
+                [2, 0, 2, 2, 0, 2],
+            ],
+            dtype=torch.long,
         )
         v = torch.tensor([3, 4, 5, 6, 7, 8], dtype=torch.float)
         sparse = torch.sparse.FloatTensor(i, v, torch.Size([2, 2, 2, 3]))
@@ -55,7 +64,10 @@ class TestDSMM(unittest.TestCase):
         self.assertLess(torch.norm(dense.grad - dense_copy.grad).item(), 1e-5)
 
     def test_backward_batch(self):
-        i = torch.tensor([[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]], dtype=torch.long)
+        i = torch.tensor(
+            [[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]],
+            dtype=torch.long,
+        )
         v = torch.tensor([3, 4, 5, 6, 7, 8], dtype=torch.float)
         sparse = torch.sparse.FloatTensor(i, v, torch.Size([2, 2, 3]))
         dense = torch.randn(2, 3, 4, requires_grad=True)
@@ -70,7 +82,13 @@ class TestDSMM(unittest.TestCase):
 
     def test_backward_multi_batch(self):
         i = torch.tensor(
-            [[0, 1, 1, 0, 0, 1], [0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]], dtype=torch.long
+            [
+                [0, 1, 1, 0, 0, 1],
+                [0, 0, 0, 1, 1, 1],
+                [0, 1, 1, 0, 1, 1],
+                [2, 0, 2, 2, 0, 2],
+            ],
+            dtype=torch.long,
         )
         v = torch.tensor([3, 4, 5, 6, 7, 8], dtype=torch.float)
         sparse = torch.sparse.FloatTensor(i, v, torch.Size([2, 2, 2, 3]))
@@ -100,7 +118,10 @@ class TestDSMM(unittest.TestCase):
         actual.backward(grad_output)
         self.assertLess(torch.norm(dense.grad - dense_copy.grad).item(), 1e-5)
 
-        i = torch.tensor([[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]], dtype=torch.long)
+        i = torch.tensor(
+            [[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]],
+            dtype=torch.long,
+        )
         v = torch.tensor([3, 4, 5, 6, 7, 8], dtype=torch.float)
         sparse = torch.sparse.FloatTensor(i, v, torch.Size([2, 2, 3]))
         dense = torch.randn(4, 2, 3, 4, requires_grad=True)
@@ -116,7 +137,10 @@ class TestDSMM(unittest.TestCase):
         self.assertLess(torch.norm(dense.grad - dense_copy.grad).item(), 1e-5)
 
     def test_broadcast_sparse(self):
-        i = torch.tensor([[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]], dtype=torch.long)
+        i = torch.tensor(
+            [[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]],
+            dtype=torch.long,
+        )
         v = torch.tensor([3, 4, 5, 6, 7, 8], dtype=torch.float)
         sparse = torch.sparse.FloatTensor(i, v, torch.Size([2, 2, 3]))
         dense = torch.randn(3, 4, requires_grad=True)
@@ -132,7 +156,10 @@ class TestDSMM(unittest.TestCase):
         self.assertLess(torch.norm(dense.grad - dense_copy.grad).item(), 1e-5)
 
     def test_broadcast_singleton(self):
-        i = torch.tensor([[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]], dtype=torch.long)
+        i = torch.tensor(
+            [[0, 0, 0, 1, 1, 1], [0, 1, 1, 0, 1, 1], [2, 0, 2, 2, 0, 2]],
+            dtype=torch.long,
+        )
         v = torch.tensor([3, 4, 5, 6, 7, 8], dtype=torch.float)
         sparse = torch.sparse.FloatTensor(i, v, torch.Size([2, 2, 3]))
         dense = torch.randn(1, 3, 4, requires_grad=True)

--- a/test/functions/test_root_decomposition.py
+++ b/test/functions/test_root_decomposition.py
@@ -39,7 +39,10 @@ class TestRootDecomposition(BaseTestCase, unittest.TestCase):
         probe_vectors = torch.randn(*mat.shape[:-2], 4, 5)
         test_vectors = torch.randn(*mat.shape[:-2], 4, 5)
         root = linear_operator.root_inv_decomposition(
-            mat, method="lanczos", initial_vectors=probe_vectors, test_vectors=test_vectors
+            mat,
+            method="lanczos",
+            initial_vectors=probe_vectors,
+            test_vectors=test_vectors,
         ).root.to_dense()
         res = root.matmul(root.mT)
         actual = mat_clone.inverse()

--- a/test/operators/test_added_diag_linear_operator.py
+++ b/test/operators/test_added_diag_linear_operator.py
@@ -37,7 +37,12 @@ class TestAddedDiagLinearOperatorBatch(LinearOperatorTestCase, unittest.TestCase
         tensor = torch.randn(3, 5, 5)
         tensor = tensor.mT.matmul(tensor).detach()
         diag = torch.tensor(
-            [[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]], requires_grad=True
+            [
+                [1.0, 2.0, 4.0, 2.0, 3.0],
+                [2.0, 1.0, 2.0, 1.0, 4.0],
+                [1.0, 2.0, 2.0, 3.0, 4.0],
+            ],
+            requires_grad=True,
         )
         return AddedDiagLinearOperator(DenseLinearOperator(tensor), DiagLinearOperator(diag))
 
@@ -58,7 +63,12 @@ class TestAddedDiagLinearOperatorMultiBatch(LinearOperatorTestCase, unittest.Tes
         tensor = tensor.mT.matmul(tensor).detach()
         diag = (
             torch.tensor(
-                [[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]], requires_grad=True
+                [
+                    [1.0, 2.0, 4.0, 2.0, 3.0],
+                    [2.0, 1.0, 2.0, 1.0, 4.0],
+                    [1.0, 2.0, 2.0, 3.0, 4.0],
+                ],
+                requires_grad=True,
             )
             .repeat(4, 1, 1)
             .detach()
@@ -97,7 +107,9 @@ class TestAddedDiagLinearOperatorPrecondOverride(unittest.TestCase):
             return precond_closure, precond_lt, logdet
 
         overrode_lt = AddedDiagLinearOperator(
-            RootLinearOperator(tensor), DiagLinearOperator(diag), preconditioner_override=nonstandard_preconditioner
+            RootLinearOperator(tensor),
+            DiagLinearOperator(diag),
+            preconditioner_override=nonstandard_preconditioner,
         )
 
         # compute a solve - mostly to make sure that we can actually perform the solve

--- a/test/operators/test_batch_repeat_linear_operator.py
+++ b/test/operators/test_batch_repeat_linear_operator.py
@@ -56,7 +56,8 @@ class TestBatchRepeatLinearOperatorMultiBatch(LinearOperatorTestCase, unittest.T
 
     def create_linear_op(self):
         toeplitz_column = torch.tensor(
-            [[[4, 0, 0, 1], [3, 0, -0.5, -1]], [[2, 0.1, 0.01, 0.0], [3, 0, -0.1, -2]]], dtype=torch.float
+            [[[4, 0, 0, 1], [3, 0, -0.5, -1]], [[2, 0.1, 0.01, 0.0], [3, 0, -0.1, -2]]],
+            dtype=torch.float,
         )
         toeplitz_column.detach_()
         return BatchRepeatLinearOperator(ToeplitzLinearOperator(toeplitz_column), torch.Size((2, 3, 1, 4)))

--- a/test/operators/test_chol_linear_operator.py
+++ b/test/operators/test_chol_linear_operator.py
@@ -17,7 +17,13 @@ class TestCholLinearOperator(LinearOperatorTestCase, unittest.TestCase):
 
     def create_linear_op(self):
         chol = torch.tensor(
-            [[3, 0, 0, 0, 0], [-1, 2, 0, 0, 0], [1, 4, 1, 0, 0], [0, 2, 3, 2, 0], [-4, -2, 1, 3, 4]],
+            [
+                [3, 0, 0, 0, 0],
+                [-1, 2, 0, 0, 0],
+                [1, 4, 1, 0, 0],
+                [0, 2, 3, 2, 0],
+                [-4, -2, 1, 3, 4],
+            ],
             dtype=torch.float,
             requires_grad=True,
         )
@@ -54,8 +60,20 @@ class TestCholLinearOperatorBatch(TestCholLinearOperator):
     def create_linear_op(self):
         chol = torch.tensor(
             [
-                [[3, 0, 0, 0, 0], [-1, 2, 0, 0, 0], [1, 4, 1, 0, 0], [0, 2, 3, 2, 0], [-4, -2, 1, 3, 4]],
-                [[2, 0, 0, 0, 0], [3, 1, 0, 0, 0], [-2, 3, 2, 0, 0], [-2, 1, -1, 3, 0], [-4, -4, 5, 2, 3]],
+                [
+                    [3, 0, 0, 0, 0],
+                    [-1, 2, 0, 0, 0],
+                    [1, 4, 1, 0, 0],
+                    [0, 2, 3, 2, 0],
+                    [-4, -2, 1, 3, 4],
+                ],
+                [
+                    [2, 0, 0, 0, 0],
+                    [3, 1, 0, 0, 0],
+                    [-2, 3, 2, 0, 0],
+                    [-2, 1, -1, 3, 0],
+                    [-4, -4, 5, 2, 3],
+                ],
             ],
             dtype=torch.float,
         )
@@ -73,8 +91,20 @@ class TestCholLinearOperatorMultiBatch(TestCholLinearOperator):
     def create_linear_op(self):
         chol = torch.tensor(
             [
-                [[3, 0, 0, 0, 0], [-1, 2, 0, 0, 0], [1, 4, 1, 0, 0], [0, 2, 3, 2, 0], [-4, -2, 1, 3, 4]],
-                [[2, 0, 0, 0, 0], [3, 1, 0, 0, 0], [-2, 3, 2, 0, 0], [-2, 1, -1, 3, 0], [-4, -4, 5, 2, 3]],
+                [
+                    [3, 0, 0, 0, 0],
+                    [-1, 2, 0, 0, 0],
+                    [1, 4, 1, 0, 0],
+                    [0, 2, 3, 2, 0],
+                    [-4, -2, 1, 3, 4],
+                ],
+                [
+                    [2, 0, 0, 0, 0],
+                    [3, 1, 0, 0, 0],
+                    [-2, 3, 2, 0, 0],
+                    [-2, 1, -1, 3, 0],
+                    [-4, -4, 5, 2, 3],
+                ],
             ],
             dtype=torch.float,
         )

--- a/test/operators/test_diag_linear_operator.py
+++ b/test/operators/test_diag_linear_operator.py
@@ -33,7 +33,8 @@ class TestDiagLinearOperator(LinearOperatorTestCase, unittest.TestCase):
         linear_op_copy = linear_op.detach().clone()
         evaluated = self.evaluate_linear_op(linear_op_copy)
         self.assertAllClose(
-            torch.exp(linear_op).diagonal(dim1=-1, dim2=-2), torch.exp(evaluated.diagonal(dim1=-1, dim2=-2))
+            torch.exp(linear_op).diagonal(dim1=-1, dim2=-2),
+            torch.exp(evaluated.diagonal(dim1=-1, dim2=-2)),
         )
 
     def test_inverse(self):
@@ -61,7 +62,8 @@ class TestDiagLinearOperator(LinearOperatorTestCase, unittest.TestCase):
         linear_op_copy = linear_op.detach().clone()
         evaluated = self.evaluate_linear_op(linear_op_copy)
         self.assertAllClose(
-            torch.log(linear_op).diagonal(dim1=-1, dim2=-2), torch.log(evaluated.diagonal(dim1=-1, dim2=-2))
+            torch.log(linear_op).diagonal(dim1=-1, dim2=-2),
+            torch.log(evaluated.diagonal(dim1=-1, dim2=-2)),
         )
 
     def test_solve_triangular(self):
@@ -92,7 +94,12 @@ class TestDiagLinearOperatorBatch(TestDiagLinearOperator):
 
     def create_linear_op(self):
         diag = torch.tensor(
-            [[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]], requires_grad=True
+            [
+                [1.0, 2.0, 4.0, 2.0, 3.0],
+                [2.0, 1.0, 2.0, 1.0, 4.0],
+                [1.0, 2.0, 2.0, 3.0, 4.0],
+            ],
+            requires_grad=True,
         )
         return DiagLinearOperator(diag)
 

--- a/test/operators/test_identity_linear_operator.py
+++ b/test/operators/test_identity_linear_operator.py
@@ -156,7 +156,10 @@ class TestIdentityLinearOperator(LinearOperatorTestCase, unittest.TestCase):
     def test_root_decomposition(self, cholesky=False):
         linear_op = self.create_linear_op()
         root_decomp = linear_op.root_decomposition().root
-        self.assertAllClose(root_decomp.to_dense(), torch.eye(linear_op.size(-1)).expand(linear_op.shape))
+        self.assertAllClose(
+            root_decomp.to_dense(),
+            torch.eye(linear_op.size(-1)).expand(linear_op.shape),
+        )
 
     def test_svd(self):
         linear_op = self.create_linear_op()

--- a/test/operators/test_interpolated_linear_operator.py
+++ b/test/operators/test_interpolated_linear_operator.py
@@ -31,7 +31,11 @@ class TestInterpolatedLinearOperator(LinearOperatorTestCase, unittest.TestCase):
         base_linear_op = DenseLinearOperator(base_tensor)
 
         return InterpolatedLinearOperator(
-            base_linear_op, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
+            base_linear_op,
+            left_interp_indices,
+            left_interp_values,
+            right_interp_indices,
+            right_interp_values,
         )
 
     def evaluate_linear_op(self, linear_op):
@@ -68,7 +72,11 @@ class TestInterpolatedLinearOperatorBatch(LinearOperatorTestCase, unittest.TestC
         base_linear_op = DenseLinearOperator(base_tensor)
 
         return InterpolatedLinearOperator(
-            base_linear_op, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
+            base_linear_op,
+            left_interp_indices,
+            left_interp_values,
+            right_interp_indices,
+            right_interp_values,
         )
 
     def evaluate_linear_op(self, linear_op):
@@ -113,7 +121,11 @@ class TestInterpolatedLinearOperatorMultiBatch(LinearOperatorTestCase, unittest.
         base_linear_op = DenseLinearOperator(base_tensor)
 
         return InterpolatedLinearOperator(
-            base_linear_op, left_interp_indices, left_interp_values, right_interp_indices, right_interp_values
+            base_linear_op,
+            left_interp_indices,
+            left_interp_values,
+            right_interp_indices,
+            right_interp_values,
         )
 
     def evaluate_linear_op(self, linear_op):
@@ -123,8 +135,16 @@ class TestInterpolatedLinearOperatorMultiBatch(LinearOperatorTestCase, unittest.
             for j in range(5):
                 left_matrix_comp = torch.zeros(4, 6, dtype=linear_op.dtype)
                 right_matrix_comp = torch.zeros(4, 6, dtype=linear_op.dtype)
-                left_matrix_comp.scatter_(1, linear_op.left_interp_indices[i, j], linear_op.left_interp_values[i, j])
-                right_matrix_comp.scatter_(1, linear_op.right_interp_indices[i, j], linear_op.right_interp_values[i, j])
+                left_matrix_comp.scatter_(
+                    1,
+                    linear_op.left_interp_indices[i, j],
+                    linear_op.left_interp_values[i, j],
+                )
+                right_matrix_comp.scatter_(
+                    1,
+                    linear_op.right_interp_indices[i, j],
+                    linear_op.right_interp_values[i, j],
+                )
                 left_matrix_comps.append(left_matrix_comp.unsqueeze(0))
                 right_matrix_comps.append(right_matrix_comp.unsqueeze(0))
         left_matrix = torch.cat(left_matrix_comps)

--- a/test/operators/test_kronecker_product_added_diag_linear_operator.py
+++ b/test/operators/test_kronecker_product_added_diag_linear_operator.py
@@ -30,7 +30,10 @@ class TestKroneckerProductAddedDiagLinearOperator(unittest.TestCase, LinearOpera
     def create_linear_op(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
-        c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
+        c = torch.tensor(
+            [[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]],
+            dtype=torch.float,
+        )
         d = 0.5 * torch.rand(24, dtype=torch.float)
         a.requires_grad_(True)
         b.requires_grad_(True)
@@ -57,7 +60,10 @@ class TestKroneckerProductAddedKroneckerDiagLinearOperator(TestKroneckerProductA
     def create_linear_op(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
-        c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
+        c = torch.tensor(
+            [[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]],
+            dtype=torch.float,
+        )
         d = torch.tensor([2, 1, 3], dtype=torch.float)
         e = torch.tensor([5], dtype=torch.float)
         f = torch.tensor([2.5], dtype=torch.float)
@@ -84,7 +90,10 @@ class TestKroneckerProductAddedKroneckerConstDiagLinearOperator(TestKroneckerPro
     def create_linear_op(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
-        c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
+        c = torch.tensor(
+            [[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]],
+            dtype=torch.float,
+        )
         d = torch.tensor([2], dtype=torch.float)
         e = torch.tensor([5], dtype=torch.float)
         f = torch.tensor([2.5], dtype=torch.float)
@@ -112,7 +121,10 @@ class TestKroneckerProductAddedConstDiagLinearOperator(TestKroneckerProductAdded
     def create_linear_op(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
-        c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
+        c = torch.tensor(
+            [[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]],
+            dtype=torch.float,
+        )
         a.requires_grad_(True)
         b.requires_grad_(True)
         c.requires_grad_(True)

--- a/test/operators/test_kronecker_product_linear_operator.py
+++ b/test/operators/test_kronecker_product_linear_operator.py
@@ -43,7 +43,10 @@ class TestKroneckerProductLinearOperator(LinearOperatorTestCase, unittest.TestCa
     def create_linear_op(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float)
-        c = torch.tensor([[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float)
+        c = torch.tensor(
+            [[4, 0.5, 1, 0], [0.5, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]],
+            dtype=torch.float,
+        )
         a.requires_grad_(True)
         b.requires_grad_(True)
         c.requires_grad_(True)
@@ -92,9 +95,10 @@ class TestKroneckerProductLinearOperatorBatch(TestKroneckerProductLinearOperator
     def create_linear_op(self):
         a = torch.tensor([[4, 0, 2], [0, 3, -1], [2, -1, 3]], dtype=torch.float).repeat(3, 1, 1)
         b = torch.tensor([[2, 1], [1, 2]], dtype=torch.float).repeat(3, 1, 1)
-        c = torch.tensor([[4, 0.1, 1, 0], [0.1, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]], dtype=torch.float).repeat(
-            3, 1, 1
-        )
+        c = torch.tensor(
+            [[4, 0.1, 1, 0], [0.1, 4, -1, 0], [1, -1, 3, 0], [0, 0, 0, 4]],
+            dtype=torch.float,
+        ).repeat(3, 1, 1)
         a.requires_grad_(True)
         b.requires_grad_(True)
         c.requires_grad_(True)

--- a/test/operators/test_low_rank_root_added_diag_linear_operator.py
+++ b/test/operators/test_low_rank_root_added_diag_linear_operator.py
@@ -111,7 +111,13 @@ class TestLowRankRootAddedDiagLinearOperatorBatch(TestLowRankRootAddedDiagLinear
 
     def create_linear_op(self):
         tensor = torch.randn(3, 5, 2)
-        diag = torch.tensor([[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]])
+        diag = torch.tensor(
+            [
+                [1.0, 2.0, 4.0, 2.0, 3.0],
+                [2.0, 1.0, 2.0, 1.0, 4.0],
+                [1.0, 2.0, 2.0, 3.0, 4.0],
+            ]
+        )
         lt = LowRankRootLinearOperator(tensor).add_diagonal(diag)
         assert isinstance(lt, LowRankRootAddedDiagLinearOperator)
         return lt
@@ -130,9 +136,13 @@ class TestLowRankRootAddedDiagLinearOperatorMultiBatch(TestLowRankRootAddedDiagL
 
     def create_linear_op(self):
         tensor = torch.randn(4, 3, 5, 2)
-        diag = torch.tensor([[1.0, 2.0, 4.0, 2.0, 3.0], [2.0, 1.0, 2.0, 1.0, 4.0], [1.0, 2.0, 2.0, 3.0, 4.0]]).repeat(
-            4, 1, 1
-        )
+        diag = torch.tensor(
+            [
+                [1.0, 2.0, 4.0, 2.0, 3.0],
+                [2.0, 1.0, 2.0, 1.0, 4.0],
+                [1.0, 2.0, 2.0, 3.0, 4.0],
+            ]
+        ).repeat(4, 1, 1)
         lt = LowRankRootLinearOperator(tensor).add_diagonal(diag)
         assert isinstance(lt, LowRankRootAddedDiagLinearOperator)
         return lt

--- a/test/operators/test_mul_linear_operator.py
+++ b/test/operators/test_mul_linear_operator.py
@@ -24,7 +24,10 @@ class TestMulLinearOperator(LinearOperatorTestCase, unittest.TestCase):
 
     def evaluate_linear_op(self, linear_op):
         diag_tensor = linear_op._diag_tensor.to_dense()
-        res = torch.mul(linear_op._linear_op.left_linear_op.to_dense(), linear_op._linear_op.right_linear_op.to_dense())
+        res = torch.mul(
+            linear_op._linear_op.left_linear_op.to_dense(),
+            linear_op._linear_op.right_linear_op.to_dense(),
+        )
         res = res + diag_tensor
         return res
 
@@ -40,7 +43,10 @@ class TestMulLinearOperatorBatch(LinearOperatorTestCase, unittest.TestCase):
 
     def evaluate_linear_op(self, linear_op):
         diag_tensor = linear_op._diag_tensor.to_dense()
-        res = torch.mul(linear_op._linear_op.left_linear_op.to_dense(), linear_op._linear_op.right_linear_op.to_dense())
+        res = torch.mul(
+            linear_op._linear_op.left_linear_op.to_dense(),
+            linear_op._linear_op.right_linear_op.to_dense(),
+        )
         res = res + diag_tensor
         return res
 
@@ -57,7 +63,10 @@ class TestMulLinearOperatorMultiBatch(LinearOperatorTestCase, unittest.TestCase)
 
     def evaluate_linear_op(self, linear_op):
         diag_tensor = linear_op._diag_tensor.to_dense()
-        res = torch.mul(linear_op._linear_op.left_linear_op.to_dense(), linear_op._linear_op.right_linear_op.to_dense())
+        res = torch.mul(
+            linear_op._linear_op.left_linear_op.to_dense(),
+            linear_op._linear_op.right_linear_op.to_dense(),
+        )
         res = res + diag_tensor
         return res
 

--- a/test/operators/test_sum_kronecker_linear_operator.py
+++ b/test/operators/test_sum_kronecker_linear_operator.py
@@ -40,6 +40,12 @@ class TestSumKroneckerLinearOperator(LinearOperatorTestCase, unittest.TestCase):
         return SumKroneckerLinearOperator(kp_lt_1, kp_lt_2)
 
     def evaluate_linear_op(self, linear_op):
-        res1 = kron(linear_op.linear_ops[0].linear_ops[0].tensor, linear_op.linear_ops[0].linear_ops[1].tensor)
-        res2 = kron(linear_op.linear_ops[1].linear_ops[0].tensor, linear_op.linear_ops[1].linear_ops[1].tensor)
+        res1 = kron(
+            linear_op.linear_ops[0].linear_ops[0].tensor,
+            linear_op.linear_ops[0].linear_ops[1].tensor,
+        )
+        res2 = kron(
+            linear_op.linear_ops[1].linear_ops[0].tensor,
+            linear_op.linear_ops[1].linear_ops[1].tensor,
+        )
         return res1 + res2

--- a/test/operators/test_sum_linear_operator.py
+++ b/test/operators/test_sum_linear_operator.py
@@ -4,7 +4,7 @@ import unittest
 
 import torch
 
-from linear_operator.operators import ToeplitzLinearOperator, to_linear_operator
+from linear_operator.operators import to_linear_operator, ToeplitzLinearOperator
 from linear_operator.test.linear_operator_test_case import LinearOperatorTestCase
 
 

--- a/test/operators/test_zero_linear_operator.py
+++ b/test/operators/test_zero_linear_operator.py
@@ -66,21 +66,53 @@ class TestZeroLinearOperator(unittest.TestCase):
         linear_op = ZeroLinearOperator(3, 5, 5)
         evaluated = linear_op.to_dense()
 
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), torch.tensor([1, 2, 0, 1]))
+        index = (
+            torch.tensor([0, 1, 1, 0]),
+            torch.tensor([0, 1, 0, 2]),
+            torch.tensor([1, 2, 0, 1]),
+        )
         self.assertTrue(approx_equal(linear_op[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
+        index = (
+            torch.tensor([0, 1, 1, 0]),
+            torch.tensor([0, 1, 0, 2]),
+            slice(None, None, None),
+        )
         self.assertTrue(approx_equal(linear_op[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1]), slice(None, None, None), torch.tensor([0, 1, 2]))
+        index = (
+            torch.tensor([0, 1, 1]),
+            slice(None, None, None),
+            torch.tensor([0, 1, 2]),
+        )
         self.assertTrue(approx_equal(linear_op[index], evaluated[index]))
-        index = (slice(None, None, None), torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]))
+        index = (
+            slice(None, None, None),
+            torch.tensor([0, 1, 1, 0]),
+            torch.tensor([0, 1, 0, 2]),
+        )
         self.assertTrue(approx_equal(linear_op[index], evaluated[index]))
-        index = (torch.tensor([0, 0, 1, 1]), slice(None, None, None), slice(None, None, None))
+        index = (
+            torch.tensor([0, 0, 1, 1]),
+            slice(None, None, None),
+            slice(None, None, None),
+        )
         self.assertTrue(approx_equal(linear_op[index].to_dense(), evaluated[index]))
-        index = (slice(None, None, None), torch.tensor([0, 0, 1, 2]), torch.tensor([0, 0, 1, 1]))
+        index = (
+            slice(None, None, None),
+            torch.tensor([0, 0, 1, 2]),
+            torch.tensor([0, 0, 1, 1]),
+        )
         self.assertTrue(approx_equal(linear_op[index], evaluated[index]))
-        index = (torch.tensor([0, 1, 1, 0]), torch.tensor([0, 1, 0, 2]), slice(None, None, None))
+        index = (
+            torch.tensor([0, 1, 1, 0]),
+            torch.tensor([0, 1, 0, 2]),
+            slice(None, None, None),
+        )
         self.assertTrue(approx_equal(linear_op[index], evaluated[index]))
-        index = (torch.tensor([0, 0, 1, 0]), slice(None, None, None), torch.tensor([0, 0, 1, 1]))
+        index = (
+            torch.tensor([0, 0, 1, 0]),
+            slice(None, None, None),
+            torch.tensor([0, 0, 1, 1]),
+        )
         self.assertTrue(approx_equal(linear_op[index], evaluated[index]))
         index = (Ellipsis, torch.tensor([0, 1, 1, 0]))
         self.assertTrue(approx_equal(linear_op[index].to_dense(), evaluated[index]))

--- a/test/test_settings.py
+++ b/test/test_settings.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python3
 
 import unittest
+
 import torch
+
 from linear_operator.settings import cholesky_jitter
 from linear_operator.test.base_test_case import BaseTestCase
 
@@ -10,9 +12,7 @@ class TestSettings(BaseTestCase, unittest.TestCase):
     def test_cholesky_jitter(self):
         # Test value and defaults.
         self.assertEqual(cholesky_jitter.value(dtype=torch.float), 1e-6)
-        self.assertEqual(
-            cholesky_jitter.value(dtype=torch.ones(1, dtype=torch.float)), 1e-6
-        )
+        self.assertEqual(cholesky_jitter.value(dtype=torch.ones(1, dtype=torch.float)), 1e-6)
         self.assertEqual(cholesky_jitter.value(dtype=torch.double), 1e-8)
         self.assertEqual(cholesky_jitter.value(dtype=torch.half), None)
         with self.assertRaisesRegex(RuntimeError, "Unsupported dtype"):

--- a/test/utils/test_getitem.py
+++ b/test/utils/test_getitem.py
@@ -12,7 +12,10 @@ class TestGetitem(unittest.TestCase):
     def test_compute_getitem_size(self):
         a = torch.tensor(0.0).expand(5, 5, 5, 5, 5)
 
-        for indices in product([torch.tensor([0, 1, 1, 0]), slice(None, None, None), 1, slice(0, 2, None)], repeat=5):
+        for indices in product(
+            [torch.tensor([0, 1, 1, 0]), slice(None, None, None), 1, slice(0, 2, None)],
+            repeat=5,
+        ):
             res = _compute_getitem_size(a, indices)
             actual = a[indices].shape
             self.assertEqual(res, actual)
@@ -20,7 +23,10 @@ class TestGetitem(unittest.TestCase):
     def test_convert_indices_to_tensors(self):
         a = torch.randn(5, 5, 5, 5, 5)
 
-        for indices in product([torch.tensor([0, 1, 1, 0]), slice(None, None, None), 1, slice(0, 2, None)], repeat=5):
+        for indices in product(
+            [torch.tensor([0, 1, 1, 0]), slice(None, None, None), 1, slice(0, 2, None)],
+            repeat=5,
+        ):
             if not any(torch.is_tensor(index) for index in indices):
                 continue
             new_indices = _convert_indices_to_tensors(a, indices)

--- a/test/utils/test_linear_cg.py
+++ b/test/utils/test_linear_cg.py
@@ -70,7 +70,13 @@ class TestLinearCG(unittest.TestCase):
 
         rhs = torch.randn(size, 50, dtype=torch.float64)
         solves, t_mats = linear_cg(
-            matrix.matmul, rhs=rhs, n_tridiag=5, max_tridiag_iter=10, max_iter=size, tolerance=0, eps=1e-15
+            matrix.matmul,
+            rhs=rhs,
+            n_tridiag=5,
+            max_tridiag_iter=10,
+            max_iter=size,
+            tolerance=0,
+            eps=1e-15,
         )
 
         # Check cg
@@ -110,7 +116,13 @@ class TestLinearCG(unittest.TestCase):
 
         rhs = torch.randn(batch, size, 10, dtype=torch.float64)
         solves, t_mats = linear_cg(
-            matrix.matmul, rhs=rhs, n_tridiag=8, max_iter=size, max_tridiag_iter=10, tolerance=0, eps=1e-30
+            matrix.matmul,
+            rhs=rhs,
+            n_tridiag=8,
+            max_iter=size,
+            max_tridiag_iter=10,
+            tolerance=0,
+            eps=1e-30,
         )
 
         # Check cg

--- a/test/utils/test_minres.py
+++ b/test/utils/test_minres.py
@@ -35,7 +35,8 @@ class TestMinres(BaseTestCase, unittest.TestCase):
         # Maybe add shifts
         if shifts is not None:
             matrix = matrix - torch.mul(
-                torch.eye(size, dtype=torch.float64), shifts.view(*shifts.shape, *[1 for _ in matrix.shape])
+                torch.eye(size, dtype=torch.float64),
+                shifts.view(*shifts.shape, *[1 for _ in matrix.shape]),
             )
 
         # Compute solves exactly

--- a/test/utils/test_permutation.py
+++ b/test/utils/test_permutation.py
@@ -19,7 +19,10 @@ class TestPermutationHelpers(BaseTestCase, unittest.TestCase):
         left_permutation = torch.tensor([[0, 1], [1, 0]])
         right_permutation = torch.tensor([1, 0])
         res = apply_permutation(A, left_permutation, right_permutation)
-        self.assertAllClose(res, torch.tensor([[[-0.75, 0.25], [2.25, -0.75]], [[0.5, 1.2], [1.2, 1.0]]]))
+        self.assertAllClose(
+            res,
+            torch.tensor([[[-0.75, 0.25], [2.25, -0.75]], [[0.5, 1.2], [1.2, 1.0]]]),
+        )
 
     def test_apply_permutation_left_partial_and_right(self):
         A = self._gen_test_psd()
@@ -32,13 +35,19 @@ class TestPermutationHelpers(BaseTestCase, unittest.TestCase):
         A = self._gen_test_psd()
         left_permutation = torch.tensor([[0, 1], [1, 0]])
         res = apply_permutation(A, left_permutation=left_permutation)
-        self.assertAllClose(res, torch.tensor([[[0.25, -0.75], [-0.75, 2.25]], [[1.2, 0.5], [1.0, 1.2]]]))
+        self.assertAllClose(
+            res,
+            torch.tensor([[[0.25, -0.75], [-0.75, 2.25]], [[1.2, 0.5], [1.0, 1.2]]]),
+        )
 
     def test_apply_permutation_right_only(self):
         A = self._gen_test_psd()
         right_permutation = torch.tensor([1, 0])
         res = apply_permutation(A, right_permutation=right_permutation)
-        self.assertAllClose(res, torch.tensor([[[-0.75, 0.25], [2.25, -0.75]], [[1.2, 1.0], [0.5, 1.2]]]))
+        self.assertAllClose(
+            res,
+            torch.tensor([[[-0.75, 0.25], [2.25, -0.75]], [[1.2, 1.0], [0.5, 1.2]]]),
+        )
 
     def test_inverse_permutation(self):
         permutation = torch.tensor([[2, 3, 4, 0, 1], [4, 3, 0, 2, 1]])


### PR DESCRIPTION
This PR introduces the us of ufmt (instead of black + isort) for auto-formatting and import sorting to avoid collisions between the two. It also upgrades some of the versions (flake8 -> 5.0.4, flake8-print -> 5.0.0, pre-commit-hooks -> 4.4.0). As a result, quire a few files were reformatted.