### PR TITLE
Re-remove @cached decorator for TriangularLinearOperator.to_dense

### DIFF
--- a/linear_operator/operators/triangular_linear_operator.py
+++ b/linear_operator/operators/triangular_linear_operator.py
@@ -160,7 +160,6 @@ class TriangularLinearOperator(LinearOperator, _TriangularLinearOperatorBase):
         added_diag_lt = self._tensor.add_diagonal(diag)
         return self.__class__(added_diag_lt, upper=self.upper)
 
-    @cached
     def to_dense(self: Float[LinearOperator, "*batch M N"]) -> Float[Tensor, "*batch M N"]:
         return self._tensor.to_dense()
 


### PR DESCRIPTION
Repeat of #51, as this snuck back in with #42.