### PR TITLE
Make jaxtyping dep install requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -77,7 +77,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         "dev": ["ufmt", "twine", "pre-commit"],
-        "test": ["flake8==5.0.4", "flake8-print==5.0.0", "pytest", "typeguard~=2.13.3"],
+        "test": ["flake8==5.0.4", "flake8-print==5.0.0", "pytest"],
     },
     test_suite="test",
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except ImportError:
     pass
 
 # Other requirements
-install_requires += ["scipy", "jaxtyping>=0.2.9", "typeguard~=2.13.3"]
+install_requires += ["scipy", "jaxtyping>=0.2.9"]
 
 
 # Get version
@@ -77,11 +77,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         "dev": ["ufmt", "twine", "pre-commit"],
-        "test": [
-            "flake8==5.0.4",
-            "flake8-print==5.0.0",
-            "pytest",
-        ],
+        "test": ["flake8==5.0.4", "flake8-print==5.0.0", "pytest", "typeguard~=2.13.3"],
     },
     test_suite="test",
 )

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except ImportError:
     pass
 
 # Other requirements
-install_requires += ["scipy"]
+install_requires += ["scipy", "jaxtyping>=0.2.9", "typeguard~=2.13.3"]
 
 
 # Get version
@@ -80,10 +80,7 @@ setup(
         "test": [
             "flake8==5.0.4",
             "flake8-print==5.0.0",
-            "jaxtyping>=0.2.9",
-            "packaging",
             "pytest",
-            "typeguard~=2.13.3",
         ],
     },
     test_suite="test",

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ except ImportError:
     pass
 
 # Other requirements
-install_requires += ["scipy", "jaxtyping>=0.2.9"]
+install_requires += ["scipy", "jaxtyping>=0.2.9", "typeguard~=2.13.3"]
 
 
 # Get version


### PR DESCRIPTION
Make jaxtyping and typeguard required dependencies

See https://github.com/cornellius-gp/linear_operator/pull/42#issuecomment-1533225278

Also removes the `packaging` dep, which is transitive through `pytest`: https://github.com/pytest-dev/pytest/blob/main/setup.cfg#L48