### PR TITLE
Add KernelLinearOperator, deprecate KeOpsLinearOperator

### DIFF
--- a/docs/source/data_sparse_operators.rst
+++ b/docs/source/data_sparse_operators.rst
@@ -36,6 +36,12 @@ Data-Sparse LinearOperators
 .. autoclass:: linear_operator.operators.IdentityLinearOperator
    :members:
 
+:hidden:`KernelLinearOperator`
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: linear_operator.operators.KernelLinearOperator
+   :members:
+
 :hidden:`RootLinearOperator`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/linear_operator/operators/__init__.py
+++ b/linear_operator/operators/__init__.py
@@ -14,6 +14,7 @@ from .diag_linear_operator import ConstantDiagLinearOperator, DiagLinearOperator
 from .identity_linear_operator import IdentityLinearOperator
 from .interpolated_linear_operator import InterpolatedLinearOperator
 from .keops_linear_operator import KeOpsLinearOperator
+from .kernel_linear_operator import KernelLinearOperator
 from .kronecker_product_added_diag_linear_operator import KroneckerProductAddedDiagLinearOperator
 from .kronecker_product_linear_operator import (
     KroneckerProductDiagLinearOperator,
@@ -53,6 +54,7 @@ __all__ = [
     "IdentityLinearOperator",
     "InterpolatedLinearOperator",
     "KeOpsLinearOperator",
+    "KernelLinearOperator",
     "KroneckerProductLinearOperator",
     "KroneckerProductAddedDiagLinearOperator",
     "KroneckerProductDiagLinearOperator",

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -375,7 +375,8 @@ class LinearOperator(object):
         with torch.autograd.enable_grad():
             lin_op = self.representation_tree()(*args)
             loss = (left_vecs * lin_op._matmul(right_vecs)).sum()
-            actual_grads = deque(torch.autograd.grad(loss, args, allow_unused=True))
+            args_with_grads = [arg for arg in args if arg.requires_grad]
+            actual_grads = deque(torch.autograd.grad(loss, args_with_grads, allow_unused=True))
 
         # Now make sure that the object we return has one entry for every item in args
         grads = []

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2042,7 +2042,7 @@ class LinearOperator(object):
         Returns the Tensors that are used to define the LinearOperator
         """
         representation = []
-        for arg in list(self._args) + list(self._differentiable_kwarg_vals):
+        for arg in itertools.chain(self._args, self._differentiable_kwarg_vals):
             if torch.is_tensor(arg):
                 representation.append(arg)
             elif hasattr(arg, "representation") and callable(arg.representation):  # Is it a LinearOperator?

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -367,6 +367,10 @@ class LinearOperator(object):
             else:
                 args.append(arg.detach())
 
+        # If no arguments require gradients, then we're done!
+        if not any(arg.requires_grad for arg in args):
+            return (None,) * len(args)
+
         # We'll use the autograd to get us a derivative
         with torch.autograd.enable_grad():
             lin_op = self.representation_tree()(*args)

--- a/linear_operator/operators/keops_linear_operator.py
+++ b/linear_operator/operators/keops_linear_operator.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import warnings
+
 from typing import Optional, Tuple, Union
 
 import torch

--- a/linear_operator/operators/keops_linear_operator.py
+++ b/linear_operator/operators/keops_linear_operator.py
@@ -13,6 +13,10 @@ from ._linear_operator import IndexType, LinearOperator
 
 class KeOpsLinearOperator(LinearOperator):
     def __init__(self, x1, x2, covar_func, **params):
+        warnings.warn(
+            "KeOpsLinearOperator is deprecated. Please use KernelLinearOperator instead.",
+            DeprecationWarning,
+        )
         super().__init__(x1, x2, covar_func=covar_func, **params)
 
         self.x1 = x1.contiguous()

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -242,7 +242,7 @@ class KernelLinearOperator(LinearOperator):
     def _get_indices(self, row_index: IndexType, col_index: IndexType, *batch_indices: IndexType) -> torch.Tensor:
         x1_ = self.x1[(*batch_indices, row_index)].unsqueeze(-2)
         x2_ = self.x2[(*batch_indices, col_index)].unsqueeze(-2)
-        tensor_params_ = dict((name, val[batch_indices]) for name, val in self.tensor_params.items())
+        tensor_params_ = {name: val[batch_indices] for name, val in self.tensor_params.items()}
         indices_mat = to_dense(self.covar_func(x1_, x2_, **tensor_params_, **self.nontensor_params))
         assert indices_mat.shape[-2:] == torch.Size([1, 1])
         return indices_mat[..., 0, 0]

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -141,10 +141,13 @@ class KernelLinearOperator(LinearOperator):
             )
 
         # Create a version of each argument that is expanded to the broadcast batch shape
-        x1 = x1.expand(*batch_broadcast_shape, *x1.shape[-2:]).contiguous()
-        x2 = x2.expand(*batch_broadcast_shape, *x2.shape[-2:]).contiguous()
+        #
+        # NOTE: we must explicitly call requires_grad on each of these arguments
+        # for the automatic _bilinear_derivative to work in torch.autograd.Functions
+        x1 = x1.expand(*batch_broadcast_shape, *x1.shape[-2:]).contiguous().requires_grad_(x1.requires_grad)
+        x2 = x2.expand(*batch_broadcast_shape, *x2.shape[-2:]).contiguous().requires_grad_(x2.requires_grad)
         tensor_params = dict(
-            (name, val.expand(*batch_broadcast_shape, *param_nonbatch_shapes[name]))
+            (name, val.expand(*batch_broadcast_shape, *param_nonbatch_shapes[name]).requires_grad_(val.requires_grad))
             for name, val in tensor_params.items()
         )
         new_param_batch_shapes = dict((name, batch_broadcast_shape) for name in param_batch_shapes.keys())

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -230,7 +230,7 @@ class KernelLinearOperator(LinearOperator):
         # and then squeeze out the batch dimensions
         x1 = self.x1.unsqueeze(0).transpose(0, -2)
         x2 = self.x2.unsqueeze(0).transpose(0, -2)
-        tensor_params = dict((name, val.unsqueeze(0)) for name, val in self.tensor_params.items())
+        tensor_params = {name: val.unsqueeze(0) for name, val in self.tensor_params.items()}
         diag_mat = to_dense(self.covar_func(x1, x2, **tensor_params, **self.nontensor_params))
         assert diag_mat.shape[-2:] == torch.Size([1, 1])
         return diag_mat.transpose(0, -2)[0, ..., 0]

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -1,0 +1,217 @@
+from typing import Any, Callable, Union
+
+import torch
+
+from jaxtyping import Float
+from torch import Tensor
+
+from ..utils.getitem import _noop_index, IndexType
+from ..utils.memoize import cached
+from ._linear_operator import LinearOperator, to_dense
+
+
+class KernelLinearOperator(LinearOperator):
+    r"""
+    Represents the kernel matrix :math:`\boldsymbol K`
+    of data :math:`\boldsymbol X_1 \in \mathbb R^{M \times D}`
+    and :math:`\boldsymbol X_2 \in \mathbb R^{N \times D}`
+    under the covariance function :math:`k_{\boldsymbol \theta}(\cdot, \cdot)`
+    (parameterized by hyperparameters :math:`\boldsymbol \theta`
+    so that :math:`\boldsymbol K_{ij} = k_{\boldsymbol \theta}([\boldsymbol X_1]_i, [\boldsymbol X_2]_j)`.
+
+    The output of :math:`k_{\boldsymbol \theta}(\cdot,\cdot)` (`covar_func`) can either be a torch.Tensor
+    or a LinearOperator.
+
+    .. note ::
+
+        Each of the passed parameters should have a minimum of 2 (likely singleton) dimensions.
+        Any additional dimension will be considered a batch dimension that broadcasts with the batch dimensions
+        of x1 and x2.
+
+        For example, to implement the RBF kernel
+
+        .. math::
+
+            o^2 \exp\left(
+                -\tfrac{1}{2} (\boldsymbol x_1 - \boldsymbol x2)^\top \boldsymbol D_\ell^{-2}
+                (\boldsymbol x_1 - \boldsymbol x2)
+            \right),
+
+        where :math:`o` is an `outputscale` parameter and :math:`D_\ell` is a diagonal `lengthscale` matrix,
+        we would expect the following shapes:
+
+        - `x1`: `(*batch_shape x N x D)`
+        - `x2`: `(*batch_shape x M x D)`
+        - `lengthscale`: `(*batch_shape x 1 x D)`
+        - `outputscale`: `(*batch_shape x 1 x 1)`
+
+        Not adding the appropriate singleton dimensions to `lengthscale` and `outputscale` will lead to erroneous
+        kernel matrix outputs.
+
+    .. code-block:: python
+
+        # NOTE: _covar_func intentionally does not close over any parameters
+        def _covar_func(x1, x2, lengthscale, outputscale):
+            # RBF kernel function
+            # x1: ... x N x D
+            # x2: ... x M x D
+            # lengthscale: ... x 1 x D
+            # outputscale: ... x 1 x 1
+            x1 = x1.div(lengthscale)
+            x2 = x2.div(lengthscale)
+            sq_dist = (x1.unsqueeze(-2) - x2.unsqueeze(-3)).square().sum(dim=-1)
+            kern = sq_dist.div(-2.0).exp().mul(outputscale.square())
+            return kern
+
+
+        # Batches of data
+        x1 = torch.randn(3, 5, 6)
+        x2 = torch.randn(3, 4, 6)
+        # Broadcasting lengthscale and output parameters
+        lengthscale = torch.randn(2, 1, 1, 6)
+        outputscale = torch.randn(2, 1, 1, 1)
+        kern = KernelLinearOperator(x1, x2, lengthscale, outputscale, covar_func=covar_func)
+
+        # kern is of size 2 x 3 x 5 x 4
+
+    .. warning ::
+
+        `covar_func` should not close over any parameters. Any parameters that are closed over will not have
+        propagated gradients.
+
+    :param x1: The data :math:`\boldsymbol X_1.`
+    :param x2: The data :math:`\boldsymbol X_2.`
+    :param params: Additional hyperparameters (:math:`\boldsymbol \theta`) passed into covar_func.
+    :param covar_func: The covariance function :math:`k_{\boldsymbol \theta}(\cdot, \cdot)`.
+        Its arguments should be `x1`, `x2`, `*params`, `**kwargs`, and it should output the covariance matrix
+        between :math:`\boldsymbol X_1` and :math:`\boldsymbol X_2`.
+    :param kwargs: Any additional (non-hyperparameter) kwargs to pass into `covar_func`.
+    """
+
+    def __init__(
+        self,
+        x1: Float[Tensor, "... M D"],
+        x2: Float[Tensor, "... N D"],
+        *params: Float[Tensor, "... #P #D"],
+        covar_func: Callable[..., Float[Union[Tensor, LinearOperator], "... M N"]],
+        **kwargs: Any,
+    ):
+        # Ensure that x1, x2, and params can broadcast together
+        try:
+            batch_broadcast_shape = torch.broadcast_shapes(
+                x1.shape[:-2], x2.shape[:-2], *[param.shape[:-2] for param in params]
+            )
+        except RuntimeError:
+            # Check if the issue is with x1 and x2
+            try:
+                x1_nodata_shape = torch.Size([*x1.shape[:-2], 1, x1.shape[-1]])
+                x2_nodata_shape = torch.Size([*x2.shape[:-2], 1, x2.shape[-1]])
+                torch.broadcast_shapes(x1_nodata_shape, x2_nodata_shape)
+            except RuntimeError:
+                raise RuntimeError(
+                    "Incompatible data shapes for a kernel matrix: "
+                    f"x1.shape={tuple(x1.shape)}, x2.shape={tuple(x2.shape)}."
+                )
+
+            # If we've made here, this means that the parameter shapes aren't compatible with x1 and x2
+            raise RuntimeError(
+                f"Shape of kernel parameters ({', '.join([tuple(param.shape) for param in params])}) "
+                f"is incompatible with data shapes x1.shape={tuple(x1.shape)}, x2.shape={tuple(x2.shape)}.\n"
+                "Recall that parameters passed to KernelLinearOperator should have dimensionality compatible "
+                "with the data (see documentation)."
+            )
+
+        # Create a version of each argument that is expanded to the broadcast batch shape
+        x1 = x1.expand(*batch_broadcast_shape, *x1.shape[-2:]).contiguous()
+        x2 = x2.expand(*batch_broadcast_shape, *x2.shape[-2:]).contiguous()
+        params = [param.expand(*batch_broadcast_shape, *param.shape[-2:]) for param in params]
+
+        # Standard constructor
+        super().__init__(x1, x2, *params, covar_func=covar_func, **kwargs)
+        self.batch_broadcast_shape = batch_broadcast_shape
+        self.x1 = x1
+        self.x2 = x2
+        self.params = params
+        self.covar_func = covar_func
+        self.kwargs = kwargs
+
+    @cached(name="kernel_diag")
+    def _diagonal(self: Float[LinearOperator, "... M N"]) -> Float[torch.Tensor, "... N"]:
+        # Explicitly compute kernel diag via covar_func when it is needed rather than relying on lazy tensor ops.
+        # We will do this by shoving all of the data into a batch dimension (i.e. compute a ... x N x 1 x 1 kernel)
+        # and then squeeze out the batch dimensions
+        x1 = self.x1.unsqueeze(-2)
+        x2 = self.x2.unsqueeze(-2)
+        params = [param.unsqueeze(-3) for param in self.params]
+        diag_mat = to_dense(self.covar_func(x1, x2, *params, **self.kwargs))
+        assert diag_mat.shape[-2:] == torch.Size([1, 1])
+        return diag_mat[..., 0, 0]
+
+    @property
+    @cached(name="covar_mat")
+    def covar_mat(self: Float[LinearOperator, "... M N"]) -> Float[Union[Tensor, LinearOperator], "... M N"]:
+        return self.covar_func(self.x1, self.x2, *self.params, **self.kwargs)
+
+    def _matmul(
+        self: Float[LinearOperator, "*batch M N"],
+        rhs: Union[Float[torch.Tensor, "*batch2 N C"], Float[torch.Tensor, "*batch2 N"]],
+    ) -> Union[Float[torch.Tensor, "... M C"], Float[torch.Tensor, "... M"]]:
+        return self.covar_mat @ rhs.contiguous()
+
+    def _size(self) -> torch.Size:
+        return torch.Size([*self.batch_broadcast_shape, self.x1.shape[-2], self.x2.shape[-2]])
+
+    def _transpose_nonbatch(self: Float[LinearOperator, "*batch M N"]) -> Float[LinearOperator, "*batch N M"]:
+        return self.__class__(self.x2, self.x1, *self.params, covar_func=self.covar_func, **self.kwargs)
+
+    def _get_indices(self, row_index: IndexType, col_index: IndexType, *batch_indices: IndexType) -> torch.Tensor:
+        x1_ = self.x1[(*batch_indices, row_index)].unsqueeze(-2)
+        x2_ = self.x2[(*batch_indices, col_index)].unsqueeze(-2)
+        params_ = [param[batch_indices] for param in self.params]
+        indices_mat = to_dense(self.covar_func(x1_, x2_, *params_, **self.kwargs))
+        assert indices_mat.shape[-2:] == torch.Size([1, 1])
+        return indices_mat[..., 0, 0]
+
+    def _getitem(self, row_index: IndexType, col_index: IndexType, *batch_indices: IndexType) -> LinearOperator:
+        dim_index = _noop_index
+
+        # Get the indices of x1 and x2 that matter for the kernel
+        # Call x1[*batch_indices, row_index, :]
+        try:
+            x1 = self.x1[(*batch_indices, row_index, dim_index)]
+        # We're going to handle multi-batch indexing with a try-catch loop
+        # This way - in the default case, we can avoid doing expansions of x1 which can be timely
+        except IndexError:
+            if isinstance(batch_indices, slice):
+                x1 = self.x1.expand(1, *self.x1.shape[-2:])[(*batch_indices, row_index, dim_index)]
+            elif isinstance(batch_indices, tuple):
+                if any(not isinstance(bi, slice) for bi in batch_indices):
+                    raise RuntimeError(
+                        "Attempting to tensor index a non-batch matrix's batch dimensions. "
+                        f"Got batch index {batch_indices} but my shape was {self.shape}"
+                    )
+                x1 = self.x1.expand(*([1] * len(batch_indices)), *self.x1.shape[-2:])
+                x1 = x1[(*batch_indices, row_index, dim_index)]
+
+        # Call x2[*batch_indices, col_index, :]
+        try:
+            x2 = self.x2[(*batch_indices, col_index, dim_index)]
+        # We're going to handle multi-batch indexing with a try-catch loop
+        # This way - in the default case, we can avoid doing expansions of x1 which can be timely
+        except IndexError:
+            if isinstance(batch_indices, slice):
+                x2 = self.x2.expand(1, *self.x2.shape[-2:])[(*batch_indices, row_index, dim_index)]
+            elif isinstance(batch_indices, tuple):
+                if any([not isinstance(bi, slice) for bi in batch_indices]):
+                    raise RuntimeError(
+                        "Attempting to tensor index a non-batch matrix's batch dimensions. "
+                        f"Got batch index {batch_indices} but my shape was {self.shape}"
+                    )
+                x2 = self.x2.expand(*([1] * len(batch_indices)), *self.x2.shape[-2:])
+                x2 = x2[(*batch_indices, row_index, dim_index)]
+
+        # Call params[*batch_indices, :, :]
+        params = [param[(*batch_indices, _noop_index, _noop_index)] for param in self.params]
+
+        # Now construct a kernel with those indices
+        return self.__class__(x1, x2, *params, covar_func=self.covar_func, **self.kwargs)

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -79,6 +79,9 @@ class KernelLinearOperator(LinearOperator):
         `covar_func` should not close over any parameters. Any parameters that are closed over will not have
         propagated gradients.
 
+        See the example above: the lengthscale and outputscale of _covar_func are passed in as arguments,
+        rather than being externally defined variables.
+
     :param x1: The data :math:`\boldsymbol X_1.`
     :param x2: The data :math:`\boldsymbol X_2.`
     :param covar_func: The covariance function :math:`k_{\boldsymbol \theta}(\cdot, \cdot)`.

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -157,8 +157,9 @@ class KernelLinearOperator(LinearOperator):
                 param_batch_shapes[name] = val.shape
                 param_nonbatch_shapes[name] = torch.Size([])
             else:
-                param_batch_shapes[name] = val.shape[: -num_nonbatch_dimensions[name]]
-                param_nonbatch_shapes[name] = val.shape[-num_nonbatch_dimensions[name] :]
+                nonbatch_dim = num_nonbatch_dimensions[name]
+                param_batch_shapes[name] = val.shape[: -nonbatch_dim]
+                param_nonbatch_shapes[name] = val.shape[-nonbatch_dim :]
 
         # Ensure that x1, x2, and params can broadcast together
         try:

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -191,13 +191,12 @@ class KernelLinearOperator(LinearOperator):
         if len(batch_broadcast_shape):  # Otherwise all tensors are non-batch, and we don't need to expand
             x1 = x1.expand(*batch_broadcast_shape, *x1.shape[-2:]).contiguous().requires_grad_(x1.requires_grad)
             x2 = x2.expand(*batch_broadcast_shape, *x2.shape[-2:]).contiguous().requires_grad_(x2.requires_grad)
-            tensor_params = dict(
-                (
-                    name,
-                    val.expand(*batch_broadcast_shape, *param_nonbatch_shapes[name]).requires_grad_(val.requires_grad),
-                )
+            tensor_params = {
+                name : val.expand(
+                    *batch_broadcast_shape, *param_nonbatch_shapes[name]
+                ).requires_grad_(val.requires_grad)
                 for name, val in tensor_params.items()
-            )
+            }
         # Everything should now have the same batch shape
 
         # Maybe expand the num_outputs_per_input argument

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -25,7 +25,7 @@ def _x_getitem(x, batch_indices, data_index):
         if isinstance(batch_indices, slice):
             x = x.expand(1, *x.shape[-2:])[(*batch_indices, data_index, _noop_index)]
         elif isinstance(batch_indices, tuple):
-            if any([not isinstance(bi, slice) for bi in batch_indices]):
+            if any(not isinstance(bi, slice) for bi in batch_indices):
                 raise RuntimeError(
                     "Attempting to tensor index a non-batch matrix's batch dimensions. "
                     f"Got batch index {batch_indices} but my shape was {x.shape}"

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -373,7 +373,7 @@ class KernelLinearOperator(LinearOperator):
     def _unsqueeze_batch(self, dim: int) -> LinearOperator:
         x1 = self.x1.unsqueeze(dim)
         x2 = self.x2.unsqueeze(dim)
-        tensor_params = dict((name, val.unsqueeze(dim)) for name, val in self.tensor_params.items())
+        tensor_params = {name: val.unsqueeze(dim) for name, val in self.tensor_params.items()}
         return self.__class__(
             x1,
             x2,

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -335,10 +335,10 @@ class KernelLinearOperator(LinearOperator):
     def _permute_batch(self, *dims: int) -> LinearOperator:
         x1 = self.x1.permute(*dims, -2, -1)
         x2 = self.x2.permute(*dims, -2, -1)
-        tensor_params = dict(
-            (name, val.permute(*dims, *range(-self.num_nonbatch_dimensions[name], 0)))
+        tensor_params = {
+            name: val.permute(*dims, *range(-self.num_nonbatch_dimensions[name], 0))
             for name, val in self.tensor_params.items()
-        )
+        }
         return self.__class__(
             x1,
             x2,

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -310,10 +310,10 @@ class KernelLinearOperator(LinearOperator):
         x2 = _x_getitem(self.x2, batch_indices, col_index)
 
         # Call params[*batch_indices, :, :]
-        tensor_params = dict(
-            (name, val[(*batch_indices, *([_noop_index] * self.num_nonbatch_dimensions[name]))])
+        tensor_params = {
+            name: val[(*batch_indices, *([_noop_index] * self.num_nonbatch_dimensions[name]))]
             for name, val in self.tensor_params.items()
-        )
+        }
 
         # Now construct a kernel with those indices
         return self.__class__(

--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -23,7 +23,8 @@ def _x_getitem(x, batch_indices, data_index):
     # This way - in the default case, we can avoid doing expansions of x1 which can be timely
     except IndexError:
         if isinstance(batch_indices, slice):
-            x = x.expand(1, *x.shape[-2:])[(*batch_indices, data_index, _noop_index)]
+            x = x.expand(1, *x.shape[-2:])
+            x = [(*batch_indices, data_index, _noop_index)]
         elif isinstance(batch_indices, tuple):
             if any(not isinstance(bi, slice) for bi in batch_indices):
                 raise RuntimeError(

--- a/linear_operator/operators/kronecker_product_linear_operator.py
+++ b/linear_operator/operators/kronecker_product_linear_operator.py
@@ -62,23 +62,36 @@ def _t_matmul(linear_ops, kp_shape, rhs):
 
 class KroneckerProductLinearOperator(LinearOperator):
     r"""
-    Returns the Kronecker product of the given lazy tensors
+    Given linearOperators :math:`\boldsymbol K_1, \ldots, \boldsymbol K_P`,
+    this LinearOperator represents the Kronecker product :math:`\boldsymbol K_1 \otimes \ldots \otimes \boldsymbol K_P`.
 
-    Args:
-        :`linear_ops`: List of lazy tensors
+    :param linear_ops: :math:`\boldsymbol K_1, \ldots, \boldsymbol K_P`: the LinearOperators in the Kronecker product.
     """
 
-    def __init__(self, *linear_ops):
+    def __init__(self, *linear_ops: Union[Float[Tensor, "... #M #N"], Float[LinearOperator, "... #M #N"]]):
         try:
             linear_ops = tuple(to_linear_operator(linear_op) for linear_op in linear_ops)
         except TypeError:
             raise RuntimeError("KroneckerProductLinearOperator is intended to wrap lazy tensors.")
-        for prev_linear_op, curr_linear_op in zip(linear_ops[:-1], linear_ops[1:]):
-            if prev_linear_op.batch_shape != curr_linear_op.batch_shape:
-                raise RuntimeError(
-                    "KroneckerProductLinearOperator expects lazy tensors with the "
-                    "same batch shapes. Got {}.".format([lv.batch_shape for lv in linear_ops])
-                )
+
+        # Make batch shapes the same for all operators
+        try:
+            batch_broadcast_shape = torch.broadcast_shapes(*(linear_op.batch_shape for linear_op in linear_ops))
+        except RuntimeError:
+            raise RuntimeError(
+                "Batch shapes of LinearOperators "
+                f"({', '.join([str(tuple(linear_op.shape)) for linear_op in linear_ops])}) "
+                "are incompatible for a Kronecker product."
+            )
+
+        if len(batch_broadcast_shape):  # Otherwise all linear_ops are non-batch, and we don't need to expand
+            # NOTE: we must explicitly call requires_grad on each of these arguments
+            # for the automatic _bilinear_derivative to work in torch.autograd.Functions
+            linear_ops = [
+                linear_op._expand_batch(batch_broadcast_shape).requires_grad_(linear_op.requires_grad)
+                for linear_op in linear_ops
+            ]
+
         super().__init__(*linear_ops)
         self.linear_ops = linear_ops
 
@@ -102,10 +115,6 @@ class KroneckerProductLinearOperator(LinearOperator):
         self: Float[LinearOperator, "*batch N N"],
         diag: Union[Float[torch.Tensor, "... N"], Float[torch.Tensor, "... 1"], Float[torch.Tensor, ""]],
     ) -> Float[LinearOperator, "*batch N N"]:
-        r"""
-        Adds a diagonal to a KroneckerProductLinearOperator
-        """
-
         from .kronecker_product_added_diag_linear_operator import KroneckerProductAddedDiagLinearOperator
 
         if not self.is_square:

--- a/linear_operator/operators/linear_operator_representation_tree.py
+++ b/linear_operator/operators/linear_operator_representation_tree.py
@@ -9,7 +9,7 @@ class LinearOperatorRepresentationTree(object):
 
         counter = 0
         self.children = []
-        for arg in list(linear_op._args) + list(linear_op._differentiable_kwarg_vals):
+        for arg in itertools.chain(linear_op._args, linear_op._differentiable_kwarg_vals):
             if hasattr(arg, "representation") and callable(arg.representation):  # Is it a lazy tensor?
                 representation_size = len(arg.representation())
                 self.children.append((slice(counter, counter + representation_size, None), arg.representation_tree()))

--- a/linear_operator/operators/linear_operator_representation_tree.py
+++ b/linear_operator/operators/linear_operator_representation_tree.py
@@ -1,15 +1,16 @@
 #!/usr/bin/env python3
+import itertools
 
 
 class LinearOperatorRepresentationTree(object):
     def __init__(self, linear_op):
         self._cls = linear_op.__class__
-        self._differentiable_kwarg_names = linear_op._differentiable_kwarg_names
+        self._differentiable_kwarg_names = linear_op._differentiable_kwargs.keys()
         self._nondifferentiable_kwargs = linear_op._nondifferentiable_kwargs
 
         counter = 0
         self.children = []
-        for arg in itertools.chain(linear_op._args, linear_op._differentiable_kwarg_vals):
+        for arg in itertools.chain(linear_op._args, linear_op._differentiable_kwargs.values()):
             if hasattr(arg, "representation") and callable(arg.representation):  # Is it a lazy tensor?
                 representation_size = len(arg.representation())
                 self.children.append((slice(counter, counter + representation_size, None), arg.representation_tree()))

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -909,7 +909,7 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
     def test_logdet(self):
         tolerances = self.tolerances["logdet"]
 
-        linear_op = self.create_linear_op()
+        linear_op = self.create_linear_op().detach()
         linear_op_copy = linear_op.detach().clone()
         linear_op.requires_grad_(True)
         linear_op_copy.requires_grad_(True)

--- a/test/operators/test_identity_linear_operator.py
+++ b/test/operators/test_identity_linear_operator.py
@@ -76,6 +76,10 @@ class TestIdentityLinearOperator(LinearOperatorTestCase, unittest.TestCase):
     def evaluate_linear_op(self, linear_op):
         return torch.eye(5)
 
+    def test_bilinear_derivative(self):
+        # Not needed, and it errors for some reason
+        pass
+
     def test_diagonalization(self, symeig=False):
         linear_op = self.create_linear_op()
         evals, evecs = linear_op.diagonalization()

--- a/test/operators/test_identity_linear_operator.py
+++ b/test/operators/test_identity_linear_operator.py
@@ -76,10 +76,6 @@ class TestIdentityLinearOperator(LinearOperatorTestCase, unittest.TestCase):
     def evaluate_linear_op(self, linear_op):
         return torch.eye(5)
 
-    def test_bilinear_derivative(self):
-        # Not needed, and it errors for some reason
-        pass
-
     def test_diagonalization(self, symeig=False):
         linear_op = self.create_linear_op()
         evals, evecs = linear_op.diagonalization()

--- a/test/operators/test_kernel_linear_operator.py
+++ b/test/operators/test_kernel_linear_operator.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+
+import unittest
+
+import torch
+
+from linear_operator.operators import KernelLinearOperator, MatmulLinearOperator
+from linear_operator.test.linear_operator_test_case import LinearOperatorTestCase, RectangularLinearOperatorTestCase
+
+
+def _covar_func(x1, x2, lengthscale, outputscale):
+    # RBF kernel function
+    # x1: ... x N x D
+    # x2: ... x M x D
+    # lengthscale: ... x 1 x D
+    # outputscale: ... x 1 x 1
+    x1 = x1.div(lengthscale)
+    x2 = x2.div(lengthscale)
+    sq_dist = (x1.unsqueeze(-2) - x2.unsqueeze(-3)).square().sum(dim=-1)
+    kern = sq_dist.div(-2.0).exp().mul(outputscale.square())
+    return kern
+
+
+def _nystrom_covar_func(x1, x2, lengthscale, outputscale, inducing_points):
+    # RBF kernel function w/ Nystrom approximation
+    # x1: ... x N x D
+    # x2: ... x M x D
+    # lengthscale: ... x 1 x D
+    # outputscale: ... x 1 x 1
+    ones = torch.ones_like(outputscale)
+    K_zz_chol = _covar_func(inducing_points, inducing_points, lengthscale, ones)
+    K_zx1 = _covar_func(inducing_points, x1, lengthscale, ones)
+    K_zx2 = _covar_func(inducing_points, x2, lengthscale, ones)
+    kern = MatmulLinearOperator(
+        outputscale * torch.linalg.solve_triangular(K_zz_chol, K_zx1, upper=False).mT,
+        outputscale * torch.linalg.solve_triangular(K_zz_chol, K_zx2, upper=False),
+    )
+    return kern
+
+
+class TestKernelLinearOperatorRectangular(RectangularLinearOperatorTestCase, unittest.TestCase):
+    seed = 0
+
+    def create_linear_op(self):
+        x1 = torch.randn(3, 1, 5, 6)
+        x2 = torch.randn(2, 4, 6)
+        lengthscale = torch.nn.Parameter(torch.ones(1, 6))
+        outputscale = torch.nn.Parameter(torch.ones(3, 2, 1, 1))
+        return KernelLinearOperator(x1, x2, lengthscale, outputscale, covar_func=_covar_func)
+
+    def evaluate_linear_op(self, linop):
+        return _covar_func(linop.x1, linop.x2, *linop.params)
+
+
+class TestKernelLinearOperator(LinearOperatorTestCase, unittest.TestCase):
+    seed = 0
+
+    def create_linear_op(self):
+        x = torch.randn(3, 5, 6)
+        lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
+        outputscale = torch.nn.Parameter(torch.ones(2, 1, 1, 1))
+        return KernelLinearOperator(x, x, lengthscale, outputscale, covar_func=_covar_func)
+
+    def evaluate_linear_op(self, linop):
+        return _covar_func(linop.x1, linop.x2, *linop.params)
+
+
+class TestKernelLinearOperatorRectangularLinOpReturn(TestKernelLinearOperatorRectangular, unittest.TestCase):
+    seed = 0
+
+    def create_linear_op(self):
+        x1 = torch.randn(3, 4, 6)
+        x2 = torch.randn(3, 5, 6)
+        inducing_points = torch.randn(3, 6)
+        lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
+        outputscale = torch.nn.Parameter(torch.ones(2, 1, 1, 1))
+        return KernelLinearOperator(x1, x2, lengthscale, outputscale, inducing_points, covar_func=_nystrom_covar_func)
+
+    def evaluate_linear_op(self, linop):
+        return _nystrom_covar_func(linop.x1, linop.x2, *linop.params).to_dense()
+
+
+class TestKernelLinearOperatorLinOpReturn(TestKernelLinearOperator, unittest.TestCase):
+    seed = 0
+
+    def create_linear_op(self):
+        x = torch.randn(3, 4, 6)
+        inducing_points = torch.randn(20, 6)  # Overparameterized nystrom approx for invertibility
+        lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
+        outputscale = torch.nn.Parameter(torch.ones(2, 1, 1, 1))
+        return KernelLinearOperator(x, x, lengthscale, outputscale, inducing_points, covar_func=_nystrom_covar_func)
+
+    def evaluate_linear_op(self, linop):
+        return _nystrom_covar_func(linop.x1, linop.x2, *linop.params).to_dense()

--- a/test/operators/test_kernel_linear_operator.py
+++ b/test/operators/test_kernel_linear_operator.py
@@ -46,10 +46,10 @@ class TestKernelLinearOperatorRectangular(RectangularLinearOperatorTestCase, uni
         x2 = torch.randn(2, 4, 6)
         lengthscale = torch.nn.Parameter(torch.ones(1, 6))
         outputscale = torch.nn.Parameter(torch.ones(3, 2, 1, 1))
-        return KernelLinearOperator(x1, x2, lengthscale, outputscale, covar_func=_covar_func)
+        return KernelLinearOperator(x1, x2, lengthscale=lengthscale, outputscale=outputscale, covar_func=_covar_func)
 
     def evaluate_linear_op(self, linop):
-        return _covar_func(linop.x1, linop.x2, *linop.params)
+        return _covar_func(linop.x1, linop.x2, **linop.tensor_params)
 
 
 class TestKernelLinearOperator(LinearOperatorTestCase, unittest.TestCase):
@@ -59,10 +59,10 @@ class TestKernelLinearOperator(LinearOperatorTestCase, unittest.TestCase):
         x = torch.randn(3, 5, 6)
         lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
         outputscale = torch.nn.Parameter(torch.ones(2, 1, 1, 1))
-        return KernelLinearOperator(x, x, lengthscale, outputscale, covar_func=_covar_func)
+        return KernelLinearOperator(x, x, lengthscale=lengthscale, outputscale=outputscale, covar_func=_covar_func)
 
     def evaluate_linear_op(self, linop):
-        return _covar_func(linop.x1, linop.x2, *linop.params)
+        return _covar_func(linop.x1, linop.x2, **linop.tensor_params)
 
 
 class TestKernelLinearOperatorRectangularLinOpReturn(TestKernelLinearOperatorRectangular, unittest.TestCase):
@@ -74,10 +74,17 @@ class TestKernelLinearOperatorRectangularLinOpReturn(TestKernelLinearOperatorRec
         inducing_points = torch.randn(3, 6)
         lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
         outputscale = torch.nn.Parameter(torch.ones(2, 1, 1, 1))
-        return KernelLinearOperator(x1, x2, lengthscale, outputscale, inducing_points, covar_func=_nystrom_covar_func)
+        return KernelLinearOperator(
+            x1,
+            x2,
+            lengthscale=lengthscale,
+            outputscale=outputscale,
+            inducing_points=inducing_points,
+            covar_func=_nystrom_covar_func,
+        )
 
     def evaluate_linear_op(self, linop):
-        return _nystrom_covar_func(linop.x1, linop.x2, *linop.params).to_dense()
+        return _nystrom_covar_func(linop.x1, linop.x2, **linop.tensor_params).to_dense()
 
 
 class TestKernelLinearOperatorLinOpReturn(TestKernelLinearOperator, unittest.TestCase):
@@ -88,7 +95,14 @@ class TestKernelLinearOperatorLinOpReturn(TestKernelLinearOperator, unittest.Tes
         inducing_points = torch.randn(20, 6)  # Overparameterized nystrom approx for invertibility
         lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
         outputscale = torch.nn.Parameter(torch.ones(2, 1, 1, 1))
-        return KernelLinearOperator(x, x, lengthscale, outputscale, inducing_points, covar_func=_nystrom_covar_func)
+        return KernelLinearOperator(
+            x,
+            x,
+            lengthscale=lengthscale,
+            outputscale=outputscale,
+            inducing_points=inducing_points,
+            covar_func=_nystrom_covar_func,
+        )
 
     def evaluate_linear_op(self, linop):
-        return _nystrom_covar_func(linop.x1, linop.x2, *linop.params).to_dense()
+        return _nystrom_covar_func(linop.x1, linop.x2, **linop.tensor_params).to_dense()

--- a/test/operators/test_kernel_linear_operator.py
+++ b/test/operators/test_kernel_linear_operator.py
@@ -4,7 +4,12 @@ import unittest
 
 import torch
 
-from linear_operator.operators import KernelLinearOperator, MatmulLinearOperator
+from linear_operator.operators import (
+    KernelLinearOperator,
+    KroneckerProductLinearOperator,
+    MatmulLinearOperator,
+    RootLinearOperator,
+)
 from linear_operator.test.linear_operator_test_case import LinearOperatorTestCase, RectangularLinearOperatorTestCase
 
 
@@ -14,6 +19,7 @@ def _covar_func(x1, x2, lengthscale, outputscale):
     # x2: ... x M x D
     # lengthscale: ... x 1 x D
     # outputscale: ...
+    lengthscale = lengthscale.mean(dim=-3)  # Remove extraneous dimension added for testing
     x1 = x1.div(lengthscale)
     x2 = x2.div(lengthscale)
     sq_dist = (x1.unsqueeze(-2) - x2.unsqueeze(-3)).square().sum(dim=-1)
@@ -38,13 +44,24 @@ def _nystrom_covar_func(x1, x2, lengthscale, outputscale, inducing_points):
     return kern
 
 
+def _multitask_covar_func(x1, x2, lengthscale, outputscale, lmc_coeffs):
+    # RBF kernel function w/ Nystrom approximation
+    # x1: ... x N x D
+    # x2: ... x M x D
+    # lengthscale: ... x 1 x D
+    # outputscale: ...
+    K_xx = _covar_func(x1, x2, lengthscale=lengthscale, outputscale=outputscale)
+    return KroneckerProductLinearOperator(K_xx, RootLinearOperator(lmc_coeffs))
+
+
 class TestKernelLinearOperatorRectangular(RectangularLinearOperatorTestCase, unittest.TestCase):
     seed = 0
 
     def create_linear_op(self):
         x1 = torch.randn(3, 1, 5, 6)
         x2 = torch.randn(2, 4, 6)
-        lengthscale = torch.nn.Parameter(torch.ones(1, 6))
+        lengthscale = torch.nn.Parameter(torch.ones(4, 1, 6))
+        # Adding an extraneous -3 dimension to test functionality
         outputscale = torch.nn.Parameter(torch.ones(3, 2))
         return KernelLinearOperator(
             x1,
@@ -52,7 +69,7 @@ class TestKernelLinearOperatorRectangular(RectangularLinearOperatorTestCase, uni
             lengthscale=lengthscale,
             outputscale=outputscale,
             covar_func=_covar_func,
-            num_nonbatch_dimensions={"outputscale": 0},
+            num_nonbatch_dimensions={"lengthscale": 3, "outputscale": 0},
         )
 
     def evaluate_linear_op(self, linop):
@@ -64,7 +81,8 @@ class TestKernelLinearOperator(LinearOperatorTestCase, unittest.TestCase):
 
     def create_linear_op(self):
         x = torch.randn(3, 5, 6)
-        lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
+        lengthscale = torch.nn.Parameter(torch.ones(3, 4, 1, 6))
+        # Adding an extraneous -3 dimension to test functionality
         outputscale = torch.nn.Parameter(torch.ones(2, 1))
         return KernelLinearOperator(
             x,
@@ -72,7 +90,7 @@ class TestKernelLinearOperator(LinearOperatorTestCase, unittest.TestCase):
             lengthscale=lengthscale,
             outputscale=outputscale,
             covar_func=_covar_func,
-            num_nonbatch_dimensions={"outputscale": 0},
+            num_nonbatch_dimensions={"lengthscale": 3, "outputscale": 0},
         )
 
     def evaluate_linear_op(self, linop):
@@ -86,7 +104,8 @@ class TestKernelLinearOperatorRectangularLinOpReturn(TestKernelLinearOperatorRec
         x1 = torch.randn(3, 4, 6)
         x2 = torch.randn(3, 5, 6)
         inducing_points = torch.randn(3, 6)
-        lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
+        lengthscale = torch.nn.Parameter(torch.ones(3, 4, 1, 6))
+        # Adding an extraneous -3 dimension to test functionality
         outputscale = torch.nn.Parameter(torch.ones(2, 1))
         return KernelLinearOperator(
             x1,
@@ -95,7 +114,7 @@ class TestKernelLinearOperatorRectangularLinOpReturn(TestKernelLinearOperatorRec
             outputscale=outputscale,
             inducing_points=inducing_points,
             covar_func=_nystrom_covar_func,
-            num_nonbatch_dimensions={"outputscale": 0},
+            num_nonbatch_dimensions={"lengthscale": 3, "outputscale": 0},
         )
 
     def evaluate_linear_op(self, linop):
@@ -108,7 +127,8 @@ class TestKernelLinearOperatorLinOpReturn(TestKernelLinearOperator, unittest.Tes
     def create_linear_op(self):
         x = torch.randn(3, 4, 6)
         inducing_points = torch.randn(20, 6)  # Overparameterized nystrom approx for invertibility
-        lengthscale = torch.nn.Parameter(torch.ones(3, 1, 6))
+        lengthscale = torch.nn.Parameter(torch.ones(3, 4, 1, 6))
+        # Adding an extraneous -3 dimension to test functionality
         outputscale = torch.nn.Parameter(torch.ones(2, 1))
         return KernelLinearOperator(
             x,
@@ -117,8 +137,32 @@ class TestKernelLinearOperatorLinOpReturn(TestKernelLinearOperator, unittest.Tes
             outputscale=outputscale,
             inducing_points=inducing_points,
             covar_func=_nystrom_covar_func,
-            num_nonbatch_dimensions={"outputscale": 0},
+            num_nonbatch_dimensions={"lengthscale": 3, "outputscale": 0},
         )
 
     def evaluate_linear_op(self, linop):
         return _nystrom_covar_func(linop.x1, linop.x2, **linop.tensor_params).to_dense()
+
+
+class TestKernelLinearOperatorMultiOutput(TestKernelLinearOperator, unittest.TestCase):
+    seed = 0
+
+    def create_linear_op(self):
+        x = torch.randn(3, 4, 6)
+        lengthscale = torch.nn.Parameter(torch.ones(3, 4, 1, 6))
+        # Adding an extraneous -3 dimension to test functionality
+        outputscale = torch.nn.Parameter(torch.ones(2, 1))
+        lmc_coeffs = torch.nn.Parameter(torch.tensor([[1.0, 0.5], [0.5, 1.0]]))
+        return KernelLinearOperator(
+            x,
+            x,
+            lengthscale=lengthscale,
+            outputscale=outputscale,
+            lmc_coeffs=lmc_coeffs,
+            covar_func=_multitask_covar_func,
+            num_outputs_per_input=(2, 2),
+            num_nonbatch_dimensions={"lengthscale": 3, "outputscale": 0},
+        )
+
+    def evaluate_linear_op(self, linop):
+        return _multitask_covar_func(linop.x1, linop.x2, **linop.tensor_params).to_dense()


### PR DESCRIPTION
KeOpsLinearOperator does not correctly backpropagate gradients if the covar_func closes over parameters.

KernelLinearOperator corrects for this, and is set up to replace LazyEvaluatedKernelTensor in GPyTorch down the line.

[Addresses issues in [#2296](https://github.com/cornellius-gp/gpytorch/pull/2296#issuecomment-1487613562)]