### PR TITLE
Add short path for LinearOperator.repeat()

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2023,15 +2023,15 @@ class LinearOperator(object):
         """
         from .batch_repeat_linear_operator import BatchRepeatLinearOperator
 
+        # Short path if no repetition is necessary
+        if all(x == 1 for x in sizes) and len(sizes) == self.dim():
+            return self
+
         if len(sizes) < 3 or tuple(sizes[-2:]) != (1, 1):
             raise RuntimeError(
                 "Invalid repeat arguments {}. Currently, repeat only works to create repeated "
                 "batches of a 2D LinearOperator.".format(tuple(sizes))
             )
-
-        # Short path if no repetition is necessary
-        if all(x == 1 for x in sizes) and len(sizes) == self.dim():
-            return self
 
         return BatchRepeatLinearOperator(self, batch_repeat=torch.Size(sizes[:-2]))
 

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -2029,6 +2029,10 @@ class LinearOperator(object):
                 "batches of a 2D LinearOperator.".format(tuple(sizes))
             )
 
+        # Short path if no repetition is necessary
+        if all(x == 1 for x in sizes) and len(sizes) == self.dim():
+            return self
+
         return BatchRepeatLinearOperator(self, batch_repeat=torch.Size(sizes[:-2]))
 
     # TODO: make this method private

--- a/test/utils/test_repeat.py
+++ b/test/utils/test_repeat.py
@@ -1,0 +1,23 @@
+import unittest
+
+import torch
+
+from linear_operator.operators.dense_linear_operator import DenseLinearOperator
+from linear_operator.test.utils import approx_equal
+
+
+class TestRepeat(unittest.TestCase):
+    def make_example(self):
+        return DenseLinearOperator(torch.randn(3, 3))
+
+    def test_repeat(self):
+        example = self.make_example()
+        repeated = example.repeat(2, 1, 1)
+        repeated_dense = example.to_dense().repeat(2, 1, 1)
+        self.assertTrue(approx_equal(repeated.to_dense(), repeated_dense))
+
+    def test_repeat_noop(self):
+        example = self.make_example()
+        repeated = example.repeat(1, 1)
+        self.assertTrue(approx_equal(repeated.to_dense(), example.to_dense()))
+        self.assertIsInstance(repeated, DenseLinearOperator)  # ensure that fast path is taken


### PR DESCRIPTION
This adds a short path for LinearOperator.repeat() if we would otherwise create a new `BatchRepeatLinearOperator` which would be a no-op.

`repeat()` is called like this for example by the constructor of `KroneckerProductLinearOperator`.

By reducing one level of indirection, we gain two benefits: a) slightly better performance (obviously), and b) some more optimizations by calling native functions instead of default `LinearOperator` functions, e.g. for `_diagonal()`.