### PR TITLE
Fix normalization of initial guess in linear_cg()

### DIFF
--- a/linear_operator/utils/linear_cg.py
+++ b/linear_operator/utils/linear_cg.py
@@ -180,6 +180,7 @@ def linear_cg(
 
     # Let's normalize. We'll un-normalize afterwards
     rhs = rhs.div(rhs_norm)
+    initial_guess = initial_guess.div(rhs_norm)
 
     # residual: residual_{0} = b_vec - lhs x_{0}
     residual = rhs - matmul_closure(initial_guess)


### PR DESCRIPTION
Seems like while `rhs` was normalized, `initial_guess` was not. As such, initializing `linear_cg()` with a good initial guess (e.g. the solution) was of no use. This PR also normalizes `initial_guess` and adds a corresponding test.