### PR TITLE
Fix type error when converting interpolated_linear_operator to double precision

### DIFF
--- a/linear_operator/operators/interpolated_linear_operator.py
+++ b/linear_operator/operators/interpolated_linear_operator.py
@@ -468,7 +468,7 @@ class InterpolatedLinearOperator(LinearOperator):
         new_kwargs = {}
         for arg in self._args:
             if hasattr(arg, "to"):
-                if arg.dtype.is_floating_point == dtype.is_floating_point:
+                if hasattr(arg, "dtype") and arg.dtype.is_floating_point == dtype.is_floating_point:
                     new_args.append(arg.to(dtype=dtype, device=device))
                 else:
                     new_args.append(arg.to(device=device))

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -1255,6 +1255,5 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
             linear_op = linear_op.to(torch.float64)
             linear_op.numpy()
         except RuntimeError:
-            raise TypeError(f"Could not convert {type(linear_op)} to double.")
-        if linear_op.dtype != torch.float64:
-            raise TypeError(f"Could not convert {type(linear_op)} to double.")
+            raise RuntimeError(f"Could not convert {type(linear_op)} to double.")
+        self.assertEqual(linear_op.dtype, torch.float64)

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -1255,4 +1255,4 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
             linear_op = linear_op.to(torch.float64)
             linear_op.numpy()
         except RuntimeError:
-            print("Could not convert interpolated_linear_operator to double.")
+            raise TypeError(f"Could not convert {type(linear_op)} to double.")

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -1249,10 +1249,12 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
                     self.assertAllClose(arg.grad, arg_copy.grad, **self.tolerances["svd"])
 
     def test_to_double(self):
-        # test if the linear_op is still functional after convert to double
+        # test if the linear_op is still functional and converted to torch.float64 after calling to(torch.float64).
         linear_op = self.create_linear_op()
         try:
             linear_op = linear_op.to(torch.float64)
             linear_op.numpy()
         except RuntimeError:
+            raise TypeError(f"Could not convert {type(linear_op)} to double.")
+        if linear_op.dtype != torch.float64:
             raise TypeError(f"Could not convert {type(linear_op)} to double.")

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -1247,3 +1247,12 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
             for arg, arg_copy in zip(linear_op.representation(), linear_op_copy.representation()):
                 if arg_copy.requires_grad and arg_copy.is_leaf and arg_copy.grad is not None:
                     self.assertAllClose(arg.grad, arg_copy.grad, **self.tolerances["svd"])
+
+    def test_to_double(self):
+        # test if the linear_op is still functional after convert to double
+        linear_op = self.create_linear_op()
+        try:
+            linear_op = linear_op.to(torch.float64)
+            linear_op.numpy()
+        except RuntimeError:
+            print("Could not convert interpolated_linear_operator to double.")

--- a/test/operators/test_interpolated_linear_operator.py
+++ b/test/operators/test_interpolated_linear_operator.py
@@ -56,14 +56,11 @@ class TestInterpolatedLinearOperator(LinearOperatorTestCase, unittest.TestCase):
             linear_op = linear_op.to(torch.float64)
             linear_op.numpy()
         except RuntimeError:
-            raise TypeError(f"Could not convert {type(linear_op)} to double.")
+            raise RuntimeError(f"Could not convert {type(linear_op)} to double.")
         if linear_op.dtype != torch.float64:
             raise TypeError(f"Could not convert {type(linear_op)} to double.")
-        if (
-            linear_op.left_interp_indices.dtype == torch.float64
-            or linear_op.right_interp_indices.dtype == torch.float64
-        ):
-            raise TypeError(f"Index tensor in {type(linear_op)} converted to double.")
+        self.assertFalse(linear_op.left_interp_indices.dtype.is_floating_point)
+        self.assertFalse(linear_op.right_interp_indices.dtype.is_floating_point)
 
 
 class TestInterpolatedLinearOperatorBatch(LinearOperatorTestCase, unittest.TestCase):

--- a/test/operators/test_interpolated_linear_operator.py
+++ b/test/operators/test_interpolated_linear_operator.py
@@ -57,8 +57,7 @@ class TestInterpolatedLinearOperator(LinearOperatorTestCase, unittest.TestCase):
             linear_op.numpy()
         except RuntimeError:
             raise RuntimeError(f"Could not convert {type(linear_op)} to double.")
-        if linear_op.dtype != torch.float64:
-            raise TypeError(f"Could not convert {type(linear_op)} to double.")
+        self.assertEqual(linear_op.dtype, torch.float64)
         self.assertFalse(linear_op.left_interp_indices.dtype.is_floating_point)
         self.assertFalse(linear_op.right_interp_indices.dtype.is_floating_point)
 

--- a/test/operators/test_interpolated_linear_operator.py
+++ b/test/operators/test_interpolated_linear_operator.py
@@ -48,6 +48,23 @@ class TestInterpolatedLinearOperator(LinearOperatorTestCase, unittest.TestCase):
         actual = left_matrix.matmul(base_tensor).matmul(right_matrix.t())
         return actual
 
+    def test_to_double(self):
+        # overwrite the test_to_double under LinearOperatorTestCase.
+        # specifically check if the index matrices are still integer after conversion.
+        linear_op = self.create_linear_op()
+        try:
+            linear_op = linear_op.to(torch.float64)
+            linear_op.numpy()
+        except RuntimeError:
+            raise TypeError(f"Could not convert {type(linear_op)} to double.")
+        if linear_op.dtype != torch.float64:
+            raise TypeError(f"Could not convert {type(linear_op)} to double.")
+        if (
+            linear_op.left_interp_indices.dtype == torch.float64
+            or linear_op.right_interp_indices.dtype == torch.float64
+        ):
+            raise TypeError(f"Index tensor in {type(linear_op)} converted to double.")
+
 
 class TestInterpolatedLinearOperatorBatch(LinearOperatorTestCase, unittest.TestCase):
     seed = 0

--- a/test/operators/test_masked_linear_operator.py
+++ b/test/operators/test_masked_linear_operator.py
@@ -25,6 +25,19 @@ class TestMaskedLinearOperator(LinearOperatorTestCase, unittest.TestCase):
         base = linear_op.base.to_dense()
         return base[..., linear_op.row_mask, :][..., linear_op.col_mask]
 
+    def test_to_double(self):
+        # overwrite the test_to_double under LinearOperatorTestCase.
+        # specifically check if the mask matrices are still boolean after conversion.
+        linear_op = self.create_linear_op()
+        try:
+            linear_op = linear_op.to(torch.float64)
+            linear_op.numpy()
+        except RuntimeError:
+            raise RuntimeError(f"Could not convert {type(linear_op)} to double.")
+        self.assertEqual(linear_op.dtype, torch.float64)
+        self.assertEqual(linear_op.col_mask.dtype, torch.bool)
+        self.assertEqual(linear_op.row_mask.dtype, torch.bool)
+
 
 class TestMaskedLinearOperatorBatch(LinearOperatorTestCase, unittest.TestCase):
     seed = 2023


### PR DESCRIPTION
- Fix type error when converting interpolated_linear_operator to double precision, as discussed in https://github.com/cornellius-gp/gpytorch/issues/1958
- Added to() method in interpolated_linear_operator.py to overwrite the default to() method in _linear_operator. For each arg, the dtype will be converted only when the original dtype and target dtype are both int/float, to avoid converting integer index matrices to float.
- Added new unit test case under linear_operator_test_case.py to test whether after calling to(torch.float64), the linear operator is still functional and can be converted to numpy array. Raise TypeError if the test failed.