### PR TITLE
Update RTD configuration.

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,8 +10,10 @@ build:
   tools:
     python: "3.8"
   jobs:
+    pre_install:  # Lock version of torch at 1.11
+      - pip install torch==1.11.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     pre_build:
-      - python -m setuptools_scm
+      - python -m setuptools_scm  # Get correct version number
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
@@ -26,4 +28,7 @@ sphinx:
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:
-    - requirements: docs/requirements.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,8 +9,7 @@ linting, testing, and building the documentation, run the following:
 ```bash
 git clone https://github.com/cornellius-gp/linear_operator.git
 cd linear_operator
-pip install -e .[dev,test]
-pip install -r docs/requirements.txt
+pip install -e ".[dev,docs,test]"
 pre-commit install
 ```
 

--- a/README.md
+++ b/README.md
@@ -394,14 +394,7 @@ If you are contributing a pull request, it is best to perform a manual installat
 ```sh
 git clone https://github.com/cornellius-gp/linear_operator.git
 cd linear_operator
-pip install -e .[dev,test]
-```
-
-To generate the documentation locally, you will also need to run the following command
-from the linear_operator folder:
-
-```sh
-pip install -r docs/requirements.txt
+pip install -e ".[dev,docs,test]"
 ```
 
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,8 +1,0 @@
-jaxtyping>=0.2.9
-myst-parser
-setuptools_scm
-sphinx
-sphinx_rtd_theme
-sphinx-autodoc-typehints
-six
-uncompyle6

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,16 @@ setup(
     python_requires=">=3.8",
     install_requires=install_requires,
     extras_require={
-        "dev": ["ufmt", "twine", "pre-commit"],
+        "dev": ["pre-commit", "setuptools_scm", "ufmt", "twine"],
+        "docs": [
+            "myst-parser",
+            "setuptools_scm",
+            "sphinx",
+            "six",
+            "sphinx_rtd_theme",
+            "sphinx-autodoc-typehints",
+            "uncompyle6",
+        ],
         "test": ["flake8==5.0.4", "flake8-print==5.0.0", "pytest"],
     },
     test_suite="test",


### PR DESCRIPTION
RTD is removing the "use system packages" feature on 29 Aug 2023. This PR ensures that our docs will sill build.