### PR TITLE
Make pytorch a conda runtime dependency

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -16,6 +16,7 @@ requirements:
     - python>=3.8
 
   run:
+    - python>=3.8
     - pytorch>=1.11
     - scipy
     - jaxtyping>=0.2.9


### PR DESCRIPTION
Analogue to https://github.com/cornellius-gp/gpytorch/pull/2457, necessary b/c of conda solver issues.