### PR TITLE
Fix dtype/device mismatch in _get_indices()

### DIFF
--- a/linear_operator/operators/diag_linear_operator.py
+++ b/linear_operator/operators/diag_linear_operator.py
@@ -70,9 +70,12 @@ class DiagLinearOperator(TriangularLinearOperator):
 
     def _get_indices(self, row_index: IndexType, col_index: IndexType, *batch_indices: IndexType) -> torch.Tensor:
         res = self._diag[(*batch_indices, row_index)]
+        # Unify device and dtype prior to comparison
+        row_index = row_index.to(device=res.device, dtype=res.dtype)
+        col_index = col_index.to(device=res.device, dtype=res.dtype)
         # If row and col index don't agree, then we have off diagonal elements
         # Those should be zero'd out
-        res = res * torch.eq(row_index, col_index).to(device=res.device, dtype=res.dtype)
+        res = res * torch.eq(row_index, col_index)
         return res
 
     def _mul_constant(


### PR DESCRIPTION
Previously, this method failed if `row_index` and `col_index` have different dtype/device. Now, we first unify these and do the comparisons afterwards.

Differing dtype/device combinations can be created for example by `_convert_indices_to_tensors()` in `__getitem__()` ([reference](https://github.com/cornellius-gp/linear_operator/blob/a00c08e1b85b6eb8499a7b64083058df8d2a00ab/linear_operator/utils/getitem.py#L98)).