### PR TITLE
Fix errors in docs

### DIFF
--- a/docs/source/linear_operator.rst
+++ b/docs/source/linear_operator.rst
@@ -6,4 +6,3 @@ LinearOperator
 
 .. autoclass:: linear_operator.LinearOperator
    :members:
-   :noindex: linear_operator.operators

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -1154,7 +1154,7 @@ class LinearOperator(object):
         generate_roots: bool = True,
         generate_inv_roots: bool = True,
         **root_decomp_kwargs,
-    ) -> Float[LinearOperator, "*batch M+O N+O"]:
+    ) -> Float[LinearOperator, "... M+O N+O"]:
         r"""
         Concatenates new rows and columns to the matrix that this LinearOperator represents, e.g.
 
@@ -1177,6 +1177,7 @@ class LinearOperator(object):
         To update :math:`\mathbf R`, we first update :math:`\mathbf L`:
 
         .. math::
+
             \begin{bmatrix}
                 \mathbf A & \mathbf B^\top \\
                 \mathbf B & \mathbf D
@@ -1194,6 +1195,7 @@ class LinearOperator(object):
         Solving this matrix equation, we get:
 
         .. math::
+
             \mathbf A &= \mathbf{EE}^\top = \mathbf{LL}^\top  \quad (\Rightarrow  \mathbf E = L) \\
             \mathbf B &= \mathbf{EF}^\top         \quad (\Rightarrow \mathbf F = \mathbf{BR}) \\
             \mathbf D &= \mathbf{FF}^\top + \mathbf{GG}^\top

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
             "six",
             "sphinx_rtd_theme",
             "sphinx-autodoc-typehints",
-            "uncompyle6",
+            "uncompyle6<=3.9.0",
         ],
         "test": ["flake8==5.0.4", "flake8-print==5.0.0", "pytest"],
     },


### PR DESCRIPTION
- Fix building issue due to error in uncompyle6 3.9.1 (lock down version)
- LinearOperator is included in the doc inventory (for automatic references)
- Small change to LinearOperator#cat_rows