### PR TITLE
Typeguard 4.3.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ except ImportError:
 install_requires += [
     "scipy",
     "jaxtyping==0.2.19",
-    "typeguard~=4.3.0",
     "mpmath>=0.19,<=1.3",  # avoid incompatibiltiy with torch+sympy with mpmath 1.4
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,13 @@ setup(
             "sphinx-autodoc-typehints",
             "uncompyle6<=3.9.0",
         ],
-        "test": ["flake8==5.0.4", "flake8-print==5.0.0", "pytest"],
+        "test": [
+            "flake8==5.0.4",
+            "flake8-print==5.0.0",
+            "pytest",
+            "typeguard~=2.13.3"  # jaxtyping seems to only be compatible with older typeguard versions
+            # https://github.com/patrick-kidger/jaxtyping/commit/77c263c3def8ea3bcb7d7642c5a8402c16cf76fb
+        ],
     },
     test_suite="test",
 )

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
 install_requires += [
     "scipy",
     "jaxtyping>=0.2.9",
-    "typeguard~=2.13.3",
+    "typeguard~=4.3.0",
     "mpmath>=0.19,<=1.3",  # avoid incompatibiltiy with torch+sympy with mpmath 1.4
 ]
 


### PR DESCRIPTION
Fixes #84 by updating typeguard to 4.X

This is important because the typeguard requirement is in conflict with ydata-profiling: https://github.com/ydataai/ydata-profiling/blob/cc7b9b36364fdcb6db6a23db5d83ad3c6e2e3c8f/requirements.txt#L23 - a commonly used EDA package.
This, in turn, prevents updates to pandas and numpy.

All unittests passed