### PR TITLE
Move typeguard to being a test requirement only

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -20,7 +20,6 @@ requirements:
     - pytorch>=1.11
     - scipy
     - jaxtyping>=0.2.9
-    - typeguard~=2.13.3
 
 test:
   imports:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ except ImportError:
 install_requires += [
     "scipy",
     "jaxtyping==0.2.19",
-    "typeguard~=2.13.3",
     "mpmath>=0.19,<=1.3",  # avoid incompatibiltiy with torch+sympy with mpmath 1.4
 ]
 
@@ -91,7 +90,7 @@ setup(
             "sphinx-autodoc-typehints",
             "uncompyle6<=3.9.0",
         ],
-        "test": ["flake8==5.0.4", "flake8-print==5.0.0", "pytest"],
+        "test": ["flake8==5.0.4", "flake8-print==5.0.0", "pytest", "typeguard>=4.3"],
     },
     test_suite="test",
 )


### PR DESCRIPTION
Fixes #84 

It doesn't seem like this is needed in the library proper? In which let's just take it out of install_requires.