### PR TITLE
Use Python 3.9 for readthedocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,10 +8,8 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.9"
+    python: "3.10"
   jobs:
-    pre_install:  # Lock version of torch at 1.11
-      - pip install torch==1.11.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     pre_build:
       - python -m setuptools_scm  # Get correct version number
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.9"
   jobs:
     pre_install:  # Lock version of torch at 1.11
       - pip install torch==1.11.0+cpu -f https://download.pytorch.org/whl/torch_stable.html


### PR DESCRIPTION
Testing out whether the failures are due to old python version