### PR TITLE
Version bump

### DIFF
--- a/.conda/meta.yaml
+++ b/.conda/meta.yaml
@@ -17,13 +17,14 @@ build:
 
 requirements:
   host:
-    - python>=3.8
+    - python>=3.10
 
   run:
-    - python>=3.8
-    - pytorch>=1.11
+    - python>=3.10
+    - jaxtyping
+    - mpmath>=0.19,<=1.3
+    - pytorch>=2.0
     - scipy
-    - jaxtyping==0.2.19
 
 test:
   imports:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
@@ -44,7 +44,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: false
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         conda install -y anaconda-client conda-build

--- a/.github/workflows/run_linter.yml
+++ b/.github/workflows/run_linter.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         pip install flake8==5.0.4 flake8-print==5.0.0 pre-commit

--- a/.github/workflows/run_test_suite.yml
+++ b/.github/workflows/run_test_suite.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: "3.8"
+        python-version: "3.10"
     - name: Install dependencies
       run: |
         if [[ ${{ matrix.pytorch-version }} = "latest" ]]; then

--- a/.github/workflows/run_type_checked_test_suite.yml
+++ b/.github/workflows/run_type_checked_test_suite.yml
@@ -27,7 +27,7 @@ jobs:
         if [[ ${{ matrix.pytorch-version }} = "latest" ]]; then
           pip install --pre torch -f https://download.pytorch.org/whl/nightly/cpu/torch_nightly.html
         else
-          pip install torch==1.11+cpu -f https://download.pytorch.org/whl/torch_stable.html
+          pip install torch==2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
           pip install "numpy<2"
         fi
         pip install -e ".[test]"

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,7 @@ build:
     python: "3.10"
   jobs:
     pre_install:  # Lock version of torch at 2.0
+      - pip install "numpy<2"  # Numpy 2.0 is not fully supported until PyTorch 2.2
       - pip install torch==2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     pre_build:
       - python -m setuptools_scm  # Get correct version number

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,10 +8,10 @@ version: 2
 build:
   os: "ubuntu-22.04"
   tools:
-    python: "3.8"
+    python: "3.10"
   jobs:
-    pre_install:  # Lock version of torch at 1.11
-      - pip install torch==1.11.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    pre_install:  # Lock version of torch at 2.0
+      - pip install torch==2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     pre_build:
       - python -m setuptools_scm  # Get correct version number
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ We use [standard sphinx docstrings](https://sphinx-rtd-tutorial.readthedocs.io/e
 
 ### Type Hints
 
-LinearOperator aims to be fully typed using Python 3.8+
+LinearOperator aims to be fully typed using Python 3.10+
 [type hints](https://www.python.org/dev/peps/pep-0484/).
 We expect any contributions to also use proper type annotations.
 We are using [jaxtyping](https://github.com/google/jaxtyping) to help us be declarative about the dimension sizes used

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Documentation](https://readthedocs.org/projects/linear-operator/badge/?version=latest)](https://linear-operator.readthedocs.io/en/latest/?badge=latest)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 
-[![Python Version](https://img.shields.io/badge/python-3.8+-blue.svg)](https://www.python.org/downloads/)
+[![Python Version](https://img.shields.io/badge/python-3.10+-blue.svg)](https://www.python.org/downloads/)
 [![Conda](https://img.shields.io/conda/v/gpytorch/linear_operator.svg)](https://anaconda.org/gpytorch/linear_operator)
 [![PyPI](https://img.shields.io/pypi/v/linear_operator.svg)](https://pypi.org/project/linear_operator)
 
@@ -359,7 +359,7 @@ See the documentation for a [full list of supported composition and decoration o
 
 ## Installation
 
-LinearOperator requires Python >= 3.8.
+LinearOperator requires Python >= 3.10.
 
 ### Standard Installation (Most Recent Stable Version)
 We recommend installing via `pip` or Anaconda:
@@ -371,7 +371,7 @@ conda install linear_operator -c gpytorch
 ```
 
 The installation requires the following packages:
-- PyTorch >= 1.11
+- PyTorch >= 2.0
 - Scipy
 
 You can customize your PyTorch installation (i.e. CUDA version, CPU only option)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,7 +125,7 @@ def _dim_to_str(dim):
             res = "#" + res
         return res
     elif isinstance(dim, jaxtyping._array_types._SymbolicDim):
-        expr = code_deparse(dim.expr).text.strip().split("return ")[1]
+        expr = dim.elem
         return f"({expr})"
     elif "jaxtyping" not in str(dim.__class__):  # Probably the case that we have an ellipsis
         return "..."

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -220,4 +220,4 @@ typehints_formatter = _process
 # @jpchen's hack to get rtd builder to install latest pytorch
 # See similar line in the install section of .travis.yml
 if "READTHEDOCS" in os.environ:
-    os.system("pip install torch==1.11.0+cpu -f https://download.pytorch.org/whl/torch_stable.html")
+    os.system("pip install torch==2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,7 +87,7 @@ html_static_path = []
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "torch": ("https://pytorch.org/docs/master/", None),
+    "torch": ("https://pytorch.org/docs/main/", None),
 }
 
 # Disable documentation inheritance so as to avoid inheriting

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,14 +117,14 @@ def _convert_internal_and_external_class_to_strings(annotation):
 
 # Convert jaxtyping dimensions into strings
 def _dim_to_str(dim):
-    if isinstance(dim, jaxtyping.array_types._NamedVariadicDim):
+    if isinstance(dim, jaxtyping._array_types._NamedVariadicDim):
         return "..."
-    elif isinstance(dim, jaxtyping.array_types._FixedDim):
+    elif isinstance(dim, jaxtyping._array_types._FixedDim):
         res = str(dim.size)
         if dim.broadcastable:
             res = "#" + res
         return res
-    elif isinstance(dim, jaxtyping.array_types._SymbolicDim):
+    elif isinstance(dim, jaxtyping._array_types._SymbolicDim):
         expr = code_deparse(dim.expr).text.strip().split("return ")[1]
         return f"({expr})"
     elif "jaxtyping" not in str(dim.__class__):  # Probably the case that we have an ellipsis

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,9 +62,14 @@ myst_enable_extensions = [
     "tasklist",  # Check boxes
 ]
 
-# We use subsections of README in docs, which start with a lower header level
-# than H1, which makes myst_parser complain. This suppresses these warnings.
-suppress_warnings = ["myst.header"]
+suppress_warnings = [
+    # We use subsections of README in docs, which start with a lower header level
+    # than H1, which makes myst_parser complain. This suppresses these warnings.
+    "myst.header",
+    # The config includes the _process function below, which is "unpickable".
+    # This suppresses warnings about caching such values.
+    "config.cache",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,6 @@ from typing import ForwardRef
 
 import jaxtyping
 import sphinx_rtd_theme  # noqa
-from uncompyle6.semantics.fragments import code_deparse
 
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "..", "..", "..")))
@@ -62,6 +61,10 @@ myst_enable_extensions = [
     "dollarmath",  # Ensure markdown math from README gets compiled into rst math
     "tasklist",  # Check boxes
 ]
+
+# We use subsections of README in docs, which start with a lower header level
+# than H1, which makes myst_parser complain. This suppresses these warnings.
+suppress_warnings = ["myst.header"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ import sys
 from setuptools import find_packages, setup
 
 REQUIRED_MAJOR = 3
-REQUIRED_MINOR = 8
+REQUIRED_MINOR = 10
 
 # Check for python version
 if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
@@ -24,7 +24,7 @@ if sys.version_info < (REQUIRED_MAJOR, REQUIRED_MINOR):
 
 readme = open("README.md").read()
 
-torch_min = "1.11"
+torch_min = "2.0"
 install_requires = [">=".join(["torch", torch_min])]
 
 # if recent dev version of PyTorch is installed, no need to install stable
@@ -77,7 +77,7 @@ setup(
         "Programming Language :: Python :: 3",
     ],
     packages=find_packages(exclude=["test", "test.*"]),
-    python_requires=">=3.8",
+    python_requires=f">={REQUIRED_MAJOR}.{REQUIRED_MINOR}",
     install_requires=install_requires,
     extras_require={
         "dev": ["pre-commit", "setuptools_scm", "ufmt", "twine"],

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ setup(
             "six",
             "sphinx_rtd_theme",
             "sphinx-autodoc-typehints",
-            "uncompyle6<=3.9.0",
         ],
         "test": [
             "flake8==5.0.4",


### PR DESCRIPTION
**Updates:**
- Python 3.8 => 3.10 (already required in BoTorch)
- Pytorch 1.11 => 2.0 (already required in GPyTorch)

**Other:**
- Make requirements consistent between `.conda/meta.yaml` and `setup.py`.