### PR TITLE
Fix docs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,7 @@ build:
     python: "3.10"
   jobs:
     pre_install:  # Lock version of torch at 2.0
+      - pip install "numpy<2"  # Numpy 2.0 is not fully supported until PyTorch 2.2
       - pip install torch==2.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     pre_build:
       - python -m setuptools_scm  # Get correct version number

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,7 +125,7 @@ def _dim_to_str(dim):
             res = "#" + res
         return res
     elif isinstance(dim, jaxtyping._array_types._SymbolicDim):
-        expr = code_deparse(dim.expr).text.strip().split("return ")[1]
+        expr = dim.elem
         return f"({expr})"
     elif "jaxtyping" not in str(dim.__class__):  # Probably the case that we have an ellipsis
         return "..."

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -87,7 +87,7 @@ html_static_path = []
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
-    "torch": ("https://pytorch.org/docs/master/", None),
+    "torch": ("https://pytorch.org/docs/main/", None),
 }
 
 # Disable documentation inheritance so as to avoid inheriting

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -117,14 +117,14 @@ def _convert_internal_and_external_class_to_strings(annotation):
 
 # Convert jaxtyping dimensions into strings
 def _dim_to_str(dim):
-    if isinstance(dim, jaxtyping.array_types._NamedVariadicDim):
+    if isinstance(dim, jaxtyping._array_types._NamedVariadicDim):
         return "..."
-    elif isinstance(dim, jaxtyping.array_types._FixedDim):
+    elif isinstance(dim, jaxtyping._array_types._FixedDim):
         res = str(dim.size)
         if dim.broadcastable:
             res = "#" + res
         return res
-    elif isinstance(dim, jaxtyping.array_types._SymbolicDim):
+    elif isinstance(dim, jaxtyping._array_types._SymbolicDim):
         expr = code_deparse(dim.expr).text.strip().split("return ")[1]
         return f"({expr})"
     elif "jaxtyping" not in str(dim.__class__):  # Probably the case that we have an ellipsis

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -62,9 +62,14 @@ myst_enable_extensions = [
     "tasklist",  # Check boxes
 ]
 
-# We use subsections of README in docs, which start with a lower header level
-# than H1, which makes myst_parser complain. This suppresses these warnings.
-suppress_warnings = ["myst.header"]
+suppress_warnings = [
+    # We use subsections of README in docs, which start with a lower header level
+    # than H1, which makes myst_parser complain. This suppresses these warnings.
+    "myst.header",
+    # The config includes the _process function below, which is "unpickable".
+    # This suppresses warnings about caching such values.
+    "config.cache",
+]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,6 @@ from typing import ForwardRef
 
 import jaxtyping
 import sphinx_rtd_theme  # noqa
-from uncompyle6.semantics.fragments import code_deparse
 
 
 sys.path.append(os.path.abspath(os.path.join(__file__, "..", "..", "..")))
@@ -62,6 +61,10 @@ myst_enable_extensions = [
     "dollarmath",  # Ensure markdown math from README gets compiled into rst math
     "tasklist",  # Check boxes
 ]
+
+# We use subsections of README in docs, which start with a lower header level
+# than H1, which makes myst_parser complain. This suppresses these warnings.
+suppress_warnings = ["myst.header"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,6 @@ setup(
             "six",
             "sphinx_rtd_theme",
             "sphinx-autodoc-typehints",
-            "uncompyle6<=3.9.0",
         ],
         "test": [
             "flake8==5.0.4",


### PR DESCRIPTION
Updates sphinx configuration to:
- Make jaxtyping parsing compatible with the latest version.
- Update the link to pytorch artifacts.
- Suppress a couple types of warnings

Also removes unused uncompyle6 dependency from the setup.py.