### PR TITLE
Remove version pins for mpmath and typeguard

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,6 @@ except ImportError:
 install_requires += [
     "scipy",
     "jaxtyping",
-    "mpmath>=0.19,<=1.3",  # avoid incompatibiltiy with torch+sympy with mpmath 1.4
 ]
 
 
@@ -93,8 +92,6 @@ setup(
             "flake8==5.0.4",
             "flake8-print==5.0.0",
             "pytest",
-            "typeguard~=2.13.3"  # jaxtyping seems to only be compatible with older typeguard versions
-            # https://github.com/patrick-kidger/jaxtyping/commit/77c263c3def8ea3bcb7d7642c5a8402c16cf76fb
         ],
     },
     test_suite="test",


### PR DESCRIPTION
These are old pins that are unnecssary at this point:
- `typeguard` is not a dependency of `jaxtyping` since https://github.com/patrick-kidger/jaxtyping/releases/tag/v0.2.35
- the `mpmath` version incompatibility has been resolved in newer sympy versions: https://github.com/sympy/sympy/issues/26273#issuecomment-2149464292