### PR TITLE
Avoid dense matrices in chol_cap_mat for ConstantDiagLinearOperator A

### DIFF
--- a/linear_operator/operators/low_rank_root_added_diag_linear_operator.py
+++ b/linear_operator/operators/low_rank_root_added_diag_linear_operator.py
@@ -40,7 +40,11 @@ class LowRankRootAddedDiagLinearOperator(AddedDiagLinearOperator):
         V = self._linear_op.root.mT
         C = ConstantDiagLinearOperator(torch.ones(*V.batch_shape, 1, device=V.device, dtype=V.dtype), V.shape[-2])
 
-        cap_mat = to_dense(C + V.matmul(A_inv.matmul(U)))
+        if isinstance(self._diag_tensor, ConstantDiagLinearOperator):
+            sigma_inv = A_inv.diag_values[0]
+            cap_mat = to_dense(C + sigma_inv * V.matmul(U))
+        else:
+            cap_mat = to_dense(C + V.matmul(A_inv.matmul(U)))
         chol_cap_mat = psd_safe_cholesky(cap_mat)
 
         return chol_cap_mat


### PR DESCRIPTION
Hey :)
`LowRankRootAddedDiagLinearOperator.chol_cap_mat()` performs the matrix operation $C + V^T D^{-1} V$ where $D$ is a diagonal matrix. In a setting as described [here](https://github.com/cornellius-gp/gpytorch/discussions/2683) this can lead to the formation of a large dense representation of $D$. In the special case of $D$ being a `ConstantDiagLinearOperator`  $D=\sigma I$ we can avoid this by using the equivalent expression $C + \sigma^{-1}  V^T V$. This PR implements this special case.

Cheers   
Aaron :)