### PR TITLE
Make linear operators pickleable

### DIFF
--- a/linear_operator/operators/kernel_linear_operator.py
+++ b/linear_operator/operators/kernel_linear_operator.py
@@ -14,6 +14,10 @@ from linear_operator.utils.getitem import _noop_index, IndexType
 from linear_operator.utils.memoize import cached
 
 
+def _default_num_nonbatch_dimensions():
+    return 2
+
+
 def _x_getitem(x, batch_indices, data_index):
     """
     Helper function to compute x[*batch_indices, data_index, :] in an efficient way.
@@ -142,9 +146,9 @@ class KernelLinearOperator(LinearOperator):
     ):
         # Change num_nonbatch_dimensions into a default dict
         if num_nonbatch_dimensions is None:
-            num_nonbatch_dimensions = defaultdict(lambda: 2)
+            num_nonbatch_dimensions = defaultdict(_default_num_nonbatch_dimensions)
         else:
-            num_nonbatch_dimensions = defaultdict(lambda: 2, **num_nonbatch_dimensions)
+            num_nonbatch_dimensions = defaultdict(_default_num_nonbatch_dimensions, **num_nonbatch_dimensions)
 
         # Divide params into tensors and non-tensors
         tensor_params = dict()

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import math
+import pickle
 import traceback
 from abc import abstractmethod
 from itertools import combinations, product
@@ -954,6 +955,16 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
         for arg, arg_copy in zip(linear_op.representation(), linear_op_copy.representation()):
             if arg_copy.requires_grad and arg_copy.is_leaf and arg_copy.grad is not None:
                 self.assertAllClose(arg.grad, arg_copy.grad, **tolerances)
+
+    def test_pickle(self):
+        linear_op = self.create_linear_op()
+
+        # Make sure that pickle works with populated caches
+        _ = linear_op.to_dense()
+
+        pickled = pickle.dumps(linear_op)
+        unpickled = pickle.loads(pickled)
+        self.assertAllClose(unpickled.to_dense(), linear_op.to_dense())
 
     def test_prod(self):
         with linear_operator.settings.fast_computations(covar_root_decomposition=False):

--- a/linear_operator/utils/memoize.py
+++ b/linear_operator/utils/memoize.py
@@ -54,7 +54,7 @@ def _cached(method=None, name=None):
 
     @functools.wraps(method)
     def g(self, *args, **kwargs):
-        cache_name = name if name is not None else method
+        cache_name = name if name is not None else method.__qualname__
         kwargs_pkl = pickle.dumps(kwargs)
         if not _is_in_cache(self, cache_name, *args, kwargs_pkl=kwargs_pkl):
             return _add_to_cache(self, cache_name, method(self, *args, **kwargs), *args, kwargs_pkl=kwargs_pkl)
@@ -72,7 +72,7 @@ def _cached_ignore_args(method=None, name=None):
 
     @functools.wraps(method)
     def g(self, *args, **kwargs):
-        cache_name = name if name is not None else method
+        cache_name = name if name is not None else method.__qualname__
         if not _is_in_cache_ignore_args(self, cache_name):
             return _add_to_cache_ignore_args(self, cache_name, method(self, *args, **kwargs))
         return _get_from_cache_ignore_args(self, cache_name)


### PR DESCRIPTION
### Context

This PR aims to fix https://github.com/cornellius-gp/gpytorch/issues/2717

The recent changes in GPyTorch v1.15 make variational models not pickle-able anymore. After digging around, it seems that the root cause lies in linear operators, as linear operators are not pickle-able in the first place. See [here](https://github.com/cornellius-gp/gpytorch/issues/2717#issuecomment-3911468697) for a code snippet.

### This PR
Claude suggested that the issue is caused by the `@cache` decorator. By default, the cache uses the original **unwrapped** function in the dictionary key; see [here](https://github.com/cornellius-gp/linear_operator/blob/34da7b6b194a2af9f3594a898e5c844d87a5e79c/linear_operator/utils/memoize.py#L57). But pickle looks up the function by the qualified name, which points to the **wrapped** function. This eventually causes a check failure in pickle dumps. This PR fixes this by using the qualified name (a string) in the dictionary key.

~~P.S. There is still a test failure in the kernel linear operator, which is likely caused by lambda functions.~~