### PR TITLE
Fix deprecated APIs, latent bugs, and code quality issues

### DIFF
--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -80,7 +80,7 @@ def _implements_second_arg(torch_function: Callable) -> Callable:
     where the first argument of the function is a torch.Tensor and the
     second argument is a LinearOperator
 
-    Examples of this include :meth:`torch.cholesky_solve`, `torch.solve`, or `torch.matmul`.
+    Examples of this include :meth:`torch.cholesky_solve`, `torch.linalg.solve`, or `torch.matmul`.
     """
 
     @functools.wraps(torch_function)

--- a/linear_operator/operators/_linear_operator.py
+++ b/linear_operator/operators/_linear_operator.py
@@ -80,7 +80,7 @@ def _implements_second_arg(torch_function: Callable) -> Callable:
     where the first argument of the function is a torch.Tensor and the
     second argument is a LinearOperator
 
-    Examples of this include :meth:`torch.cholesky_solve`, `torch.linalg.solve`, or `torch.matmul`.
+    Examples of this include `torch.linalg.solve` or `torch.matmul`.
     """
 
     @functools.wraps(torch_function)

--- a/linear_operator/operators/batch_repeat_linear_operator.py
+++ b/linear_operator/operators/batch_repeat_linear_operator.py
@@ -139,8 +139,8 @@ class BatchRepeatLinearOperator(LinearOperator):
         So that the tensor is now rb x m x n.
         """
         if hasattr(self, "_batch_move_memo"):
-            padded_base_batch_shape, batch_repeat = self.__batch_move_memo
-            del self.__batch_move_memo
+            _, padded_base_batch_shape, batch_repeat = self._batch_move_memo
+            del self._batch_move_memo
         else:
             padding_dims = torch.Size(tuple(1 for _ in range(max(len(output_shape) - self.base_linear_op.dim(), 0))))
             padded_base_batch_shape = padding_dims + self.base_linear_op.batch_shape
@@ -188,7 +188,7 @@ class BatchRepeatLinearOperator(LinearOperator):
         batch_matrix = batch_matrix.permute(*batch_dims, -2, -1, *repeat_dims).contiguous()
         batch_matrix = batch_matrix.view(*self.base_linear_op.batch_shape, output_shape[-2], -1)
 
-        self.__batch_move_memo = output_shape, padded_base_batch_shape, batch_repeat
+        self._batch_move_memo = output_shape, padded_base_batch_shape, batch_repeat
         return batch_matrix
 
     def _permute_batch(self, *dims: int) -> LinearOperator:

--- a/linear_operator/operators/cat_linear_operator.py
+++ b/linear_operator/operators/cat_linear_operator.py
@@ -11,7 +11,6 @@ from linear_operator.operators._linear_operator import IndexType, LinearOperator
 from linear_operator.operators.dense_linear_operator import DenseLinearOperator, to_linear_operator
 
 from linear_operator.utils.broadcasting import _matmul_broadcast_shape
-from linear_operator.utils.deprecation import bool_compat
 from linear_operator.utils.generic import _to_helper
 from linear_operator.utils.getitem import _noop_index
 
@@ -188,7 +187,7 @@ class CatLinearOperator(LinearOperator):
 
         # Find out for which indices we switch to different tensors
         target_tensors = self.idx_to_tensor_idx[cat_dim_indices]
-        does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=bool_compat, device=self.device)
+        does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=torch.bool, device=self.device)
         torch.ne(target_tensors[:-1], target_tensors[1:], out=does_switch_tensor[1:-1])
 
         # Get the LinearOperators that will comprise the new LinearOperator
@@ -258,7 +257,7 @@ class CatLinearOperator(LinearOperator):
 
             # Find out for which indices we switch to different tensors
             target_tensors = self.idx_to_tensor_idx[cat_dim_indices]
-            does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=bool_compat, device=self.device)
+            does_switch_tensor = torch.ones(target_tensors.numel() + 1, dtype=torch.bool, device=self.device)
             torch.ne(target_tensors[:-1], target_tensors[1:], out=does_switch_tensor[1:-1])
 
             # Get the LinearOperators that will comprise the new LinearOperator
@@ -294,7 +293,7 @@ class CatLinearOperator(LinearOperator):
 
         else:
             raise RuntimeError(
-                "Unexpected index type {cat_dim_indices.__class__.__name__}. This is a bug in LinearOperator."
+                f"Unexpected index type {cat_dim_indices.__class__.__name__}. This is a bug in LinearOperator."
             )
 
         # Process the list

--- a/linear_operator/operators/kronecker_product_linear_operator.py
+++ b/linear_operator/operators/kronecker_product_linear_operator.py
@@ -35,7 +35,7 @@ def _matmul(linear_ops, kp_shape, rhs):
     output_shape = _matmul_broadcast_shape(kp_shape, rhs.shape)
     output_batch_shape = output_shape[:-2]
 
-    res = rhs.contiguous().expand(*output_batch_shape, *rhs.shape[-2:])
+    res = rhs.expand(*output_batch_shape, *rhs.shape[-2:])
     num_cols = rhs.size(-1)
     for linear_op in linear_ops:
         res = res.view(*output_batch_shape, linear_op.size(-1), -1)
@@ -50,7 +50,7 @@ def _t_matmul(linear_ops, kp_shape, rhs):
     output_shape = _matmul_broadcast_shape(kp_t_shape, rhs.shape)
     output_batch_shape = torch.Size(output_shape[:-2])
 
-    res = rhs.contiguous().expand(*output_batch_shape, *rhs.shape[-2:])
+    res = rhs.expand(*output_batch_shape, *rhs.shape[-2:])
     num_cols = rhs.size(-1)
     for linear_op in linear_ops:
         res = res.view(*output_batch_shape, linear_op.size(-2), -1)

--- a/linear_operator/operators/low_rank_root_added_diag_linear_operator.py
+++ b/linear_operator/operators/low_rank_root_added_diag_linear_operator.py
@@ -77,7 +77,9 @@ class LowRankRootAddedDiagLinearOperator(AddedDiagLinearOperator):
         chol_cap_mat = self.chol_cap_mat
 
         res = V.matmul(A_inv.matmul(rhs))
-        res = torch.cholesky_solve(res, chol_cap_mat)
+        res = torch.linalg.solve_triangular(
+            chol_cap_mat.mT, torch.linalg.solve_triangular(chol_cap_mat, res, upper=False), upper=True
+        )
         res = A_inv.matmul(U.matmul(res))
 
         solve = A_inv.matmul(rhs) - res

--- a/linear_operator/operators/sum_linear_operator.py
+++ b/linear_operator/operators/sum_linear_operator.py
@@ -28,7 +28,7 @@ class SumLinearOperator(LinearOperator):
     def _diagonal(
         self: LinearOperator,  # shape: (..., M, N)
     ) -> torch.Tensor:  # shape: (..., N)
-        return sum(linear_op._diagonal().contiguous() for linear_op in self.linear_ops)
+        return sum(linear_op._diagonal() for linear_op in self.linear_ops)
 
     def _expand_batch(
         self: LinearOperator, batch_shape: torch.Size | list[int]  # shape: (..., M, N)

--- a/linear_operator/operators/triangular_linear_operator.py
+++ b/linear_operator/operators/triangular_linear_operator.py
@@ -194,7 +194,7 @@ class TriangularLinearOperator(LinearOperator, _TriangularLinearOperatorBase):
             inv_quad_term = (inv_quad_rhs * self.solve(inv_quad_rhs)).sum(dim=-2)
         if logdet:
             diag = self._diagonal()
-            logdet_term = self._diagonal().abs().log().sum(-1)
+            logdet_term = diag.abs().log().sum(-1)
             if torch.sign(diag).prod(-1) < 0:
                 logdet_term = torch.full_like(logdet_term, float("nan"))
         else:

--- a/linear_operator/test/linear_operator_test_case.py
+++ b/linear_operator/test/linear_operator_test_case.py
@@ -667,7 +667,6 @@ class LinearOperatorTestCase(RectangularLinearOperatorTestCase):
 
     def test_add_low_rank(self):
         linear_op = self.create_linear_op()
-        linear_op = self.create_linear_op()
         evaluated = self.evaluate_linear_op(linear_op)
         new_rows = torch.randn(*linear_op.shape[:-1], 3)
 

--- a/linear_operator/utils/deprecation.py
+++ b/linear_operator/utils/deprecation.py
@@ -4,10 +4,6 @@ from __future__ import annotations
 import functools
 import warnings
 
-import torch
-
-bool_compat = torch.bool
-
 
 class DeprecationError(Exception):
     pass

--- a/linear_operator/utils/deprecation.py
+++ b/linear_operator/utils/deprecation.py
@@ -3,15 +3,10 @@ from __future__ import annotations
 
 import functools
 import warnings
-from unittest.mock import MagicMock
 
 import torch
 
-# TODO: Use bool instead of uint8 dtype once pytorch #21113 is in stable release
-if isinstance(torch, MagicMock):
-    bool_compat = torch.uint8
-else:
-    bool_compat = (torch.ones(1) > 0).dtype
+bool_compat = torch.bool
 
 
 class DeprecationError(Exception):

--- a/linear_operator/utils/linear_cg.py
+++ b/linear_operator/utils/linear_cg.py
@@ -6,7 +6,6 @@ import warnings
 import torch
 
 from linear_operator import settings
-from linear_operator.utils.deprecation import bool_compat
 from linear_operator.utils.warnings import NumericalWarning
 
 
@@ -219,7 +218,7 @@ def linear_cg(
         mul_storage = torch.empty_like(residual)
         alpha = torch.empty(*batch_shape, 1, rhs.size(-1), dtype=residual.dtype, device=residual.device)
         beta = torch.empty_like(alpha)
-        is_zero = torch.empty(*batch_shape, 1, rhs.size(-1), dtype=bool_compat, device=residual.device)
+        is_zero = torch.empty(*batch_shape, 1, rhs.size(-1), dtype=torch.bool, device=residual.device)
 
     # Define tridiagonal matrices, if applicable
     if n_tridiag:
@@ -231,7 +230,7 @@ def linear_cg(
             dtype=alpha.dtype,
             device=alpha.device,
         )
-        alpha_tridiag_is_zero = torch.empty(*batch_shape, n_tridiag, dtype=bool_compat, device=t_mat.device)
+        alpha_tridiag_is_zero = torch.empty(*batch_shape, n_tridiag, dtype=torch.bool, device=t_mat.device)
         alpha_reciprocal = torch.empty(*batch_shape, n_tridiag, dtype=t_mat.dtype, device=t_mat.device)
         prev_alpha_reciprocal = torch.empty_like(alpha_reciprocal)
         prev_beta = torch.empty_like(alpha_reciprocal)

--- a/linear_operator/utils/sparse.py
+++ b/linear_operator/utils/sparse.py
@@ -125,7 +125,7 @@ def bdsmm(sparse, dense):
         return res
 
     else:
-        return torch.mm(sparse, dense)
+        return torch.sparse.mm(sparse, dense)
 
 
 def sparse_eye(size):

--- a/linear_operator/utils/sparse.py
+++ b/linear_operator/utils/sparse.py
@@ -58,13 +58,10 @@ def make_sparse_from_indices_and_values(interp_indices, interp_values, num_rows)
         value_tensor = value_tensor.resize_(1).zero_()
 
     # Make the sparse tensor
-    type_name = value_tensor.type().split(".")[-1]  # e.g. FloatTensor
     interp_size = torch.Size((*batch_shape, num_rows, n_target_points))
-    if index_tensor.is_cuda:
-        cls = getattr(torch.cuda.sparse, type_name)
-    else:
-        cls = getattr(torch.sparse, type_name)
-    res = cls(index_tensor, value_tensor, interp_size)
+    res = torch.sparse_coo_tensor(
+        index_tensor, value_tensor, interp_size, dtype=value_tensor.dtype, device=value_tensor.device
+    )
 
     # Wrap things as a variable, if necessary
     return res
@@ -114,7 +111,7 @@ def bdsmm(sparse, dense):
         )
 
         dense_2d = dense.reshape(batch_size * num_cols, -1)
-        res = torch.dsmm(sparse_2d, dense_2d)
+        res = torch.mm(sparse_2d, dense_2d)
         res = res.view(*batch_shape, num_rows, -1)
         return res
 
@@ -122,13 +119,13 @@ def bdsmm(sparse, dense):
         *batch_shape, num_rows, num_cols = dense.size()
         batch_size = torch.Size(batch_shape).numel()
         dense = dense.view(batch_size, num_rows, num_cols)
-        res = torch.dsmm(sparse, dense.transpose(0, 1).reshape(-1, batch_size * num_cols))
+        res = torch.mm(sparse, dense.transpose(0, 1).reshape(-1, batch_size * num_cols))
         res = res.view(-1, batch_size, num_cols)
         res = res.transpose(0, 1).reshape(*batch_shape, -1, num_cols)
         return res
 
     else:
-        return torch.dsmm(sparse, dense)
+        return torch.mm(sparse, dense)
 
 
 def sparse_eye(size):
@@ -137,8 +134,7 @@ def sparse_eye(size):
     """
     indices = torch.arange(0, size).long().unsqueeze(0).expand(2, size)
     values = torch.tensor(1.0).expand(size)
-    cls = getattr(torch.sparse, values.type().split(".")[-1])
-    return cls(indices, values, torch.Size([size, size]))
+    return torch.sparse_coo_tensor(indices, values, torch.Size([size, size]))
 
 
 def sparse_getitem(sparse, idxs):
@@ -273,8 +269,4 @@ def to_sparse(dense):
         values = torch.tensor(0, dtype=dense.dtype, device=dense.device)
 
     # Construct sparse tensor
-    klass = getattr(torch.sparse, dense.type().split(".")[-1])
-    res = klass(indices.t(), values, dense.size())
-    if dense.is_cuda:
-        res = res.cuda()
-    return res
+    return torch.sparse_coo_tensor(indices.t(), values, dense.size(), dtype=dense.dtype, device=dense.device)

--- a/linear_operator/utils/stochastic_lq.py
+++ b/linear_operator/utils/stochastic_lq.py
@@ -6,7 +6,7 @@ import torch
 from linear_operator.utils.lanczos import lanczos_tridiag
 
 
-class StochasticLQ(object):
+class StochasticLQ:
     """
     Implements an approximate log determinant calculation for symmetric positive definite matrices
     using stochastic Lanczos quadrature. For efficient calculation of derivatives, We additionally


### PR DESCRIPTION
### Summary

  Follow-up to #127. Audited the codebase for remaining deprecated API usage, latent bugs, and code quality issues.

###   Deprecated API Replacements

  - torch.cholesky_solve → torch.linalg.solve_triangular (low_rank_root_added_diag_linear_operator.py): torch.cholesky_solve has been deprecated since PyTorch 1.9.
  Replaced with two chained torch.linalg.solve_triangular calls (forward solve with L, then back-substitution with L^T).
  - torch.dsmm → torch.mm (sparse.py, 3 call sites): torch.dsmm is an undocumented/legacy sparse-dense matrix multiply. torch.mm handles sparse inputs natively.
  - Old-style sparse tensor constructors → torch.sparse_coo_tensor (sparse.py, 3 call sites): Replaced getattr(torch.sparse, "FloatTensor")(...) patterns with the
  modern torch.sparse_coo_tensor().
  - bool_compat workaround → torch.bool (deprecation.py, linear_cg.py, cat_linear_operator.py): Removed workaround for PyTorch issue #21113 (resolved since PyTorch
  1.2). Replaced all bool_compat with torch.bool directly.

###   Bug Fixes

  - Missing f-string prefix (cat_linear_operator.py:297): Error message "Unexpected index type {cat_dim_indices.__class__.__name__}..." was missing the f prefix —
  the {...} was printed literally instead of interpolated.
  - _batch_move_memo naming and tuple mismatch (batch_repeat_linear_operator.py): Two bugs: (1) The setter used self.__batch_move_memo (name-mangled) but hasattr
  checked _batch_move_memo — the memo was never retrieved. (2) The setter stored a 3-tuple but the getter unpacked only 2 values, which would raise ValueError if
  ever hit. Fixed by using _batch_move_memo consistently and unpacking all 3 values.
  - Duplicate _diagonal() call (triangular_linear_operator.py:197): self._diagonal() was called twice — once stored in diag, then called again for logdet_term. Used
   the already-computed diag instead.

###   Code Quality

  - Removed duplicate create_linear_op() call in test_add_low_rank
  - Updated stale torch.solve comment → torch.linalg.solve
  - class StochasticLQ(object) → class StochasticLQ:
  - Removed unnecessary .contiguous() calls before .expand() and summation