### PR TITLE
Replace deprecated torch.jit.script with torch.compile

### DIFF
--- a/linear_operator/utils/linear_cg.py
+++ b/linear_operator/utils/linear_cg.py
@@ -14,7 +14,7 @@ def _default_preconditioner(x):
     return x.clone()
 
 
-@torch.jit.script
+@torch.compile
 def _jit_linear_cg_updates(
     result,
     alpha,
@@ -47,7 +47,7 @@ def _jit_linear_cg_updates(
     curr_conjugate_vec.mul_(beta).add_(precond_residual)
 
 
-@torch.jit.script
+@torch.compile
 def _jit_linear_cg_updates_no_precond(
     mvms,
     result,


### PR DESCRIPTION
## Summary
Follow-up to #128, replacing the two `@torch.jit.script` decorators in `linear_operator/utils/linear_cg.py` with `@torch.compile`

## Motivation
`torch.jit.script` has been deprecated in recent PyTorch versions, raising a `DeprecationWarning` at import time:
```python
DeprecationWarning: torch.jit.script is deprecated. Please switch to torch.compile or torch.export.
```