### PR TITLE
Avoid torch.sparse_coo_tensor DeprecationWarning

### DIFF
--- a/linear_operator/utils/interpolation.py
+++ b/linear_operator/utils/interpolation.py
@@ -69,6 +69,7 @@ def left_t_interp(interp_indices, interp_values, rhs, output_dim):
         size,
         dtype=summing_matrix_values.dtype,
         device=summing_matrix_values.device,
+        check_invariants=False,
     )
 
     # Sum up the values appropriately by performing sparse matrix multiplication

--- a/linear_operator/utils/sparse.py
+++ b/linear_operator/utils/sparse.py
@@ -60,7 +60,12 @@ def make_sparse_from_indices_and_values(interp_indices, interp_values, num_rows)
     # Make the sparse tensor
     interp_size = torch.Size((*batch_shape, num_rows, n_target_points))
     res = torch.sparse_coo_tensor(
-        index_tensor, value_tensor, interp_size, dtype=value_tensor.dtype, device=value_tensor.device
+        index_tensor,
+        value_tensor,
+        interp_size,
+        dtype=value_tensor.dtype,
+        device=value_tensor.device,
+        check_invariants=False,
     )
 
     # Wrap things as a variable, if necessary
@@ -108,6 +113,7 @@ def bdsmm(sparse, dense):
             torch.Size((batch_size * num_rows, batch_size * num_cols)),
             dtype=sparse._values().dtype,
             device=sparse._values().device,
+            check_invariants=False,
         )
 
         dense_2d = dense.reshape(batch_size * num_cols, -1)
@@ -134,7 +140,7 @@ def sparse_eye(size):
     """
     indices = torch.arange(0, size).long().unsqueeze(0).expand(2, size)
     values = torch.tensor(1.0).expand(size)
-    return torch.sparse_coo_tensor(indices, values, torch.Size([size, size]))
+    return torch.sparse_coo_tensor(indices, values, torch.Size([size, size]), check_invariants=False)
 
 
 def sparse_getitem(sparse, idxs):
@@ -203,7 +209,9 @@ def sparse_getitem(sparse, idxs):
             case _:
                 raise RuntimeError("Unknown index type")
 
-    return torch.sparse_coo_tensor(indices, values, torch.Size(size), dtype=values.dtype, device=values.device)
+    return torch.sparse_coo_tensor(
+        indices, values, torch.Size(size), dtype=values.dtype, device=values.devicei, check_invariants=False
+    )
 
 
 def sparse_repeat(sparse, *repeat_sizes):
@@ -232,6 +240,7 @@ def sparse_repeat(sparse, *repeat_sizes):
             torch.Size((*[1 for _ in range(num_new_dims)], *sparse.shape)),
             dtype=sparse.dtype,
             device=sparse.device,
+            check_invariants=False,
         )
 
     for i, repeat_size in enumerate(repeat_sizes):
@@ -253,6 +262,7 @@ def sparse_repeat(sparse, *repeat_sizes):
                 ),
                 dtype=sparse.dtype,
                 device=sparse.device,
+                check_invariants=False,
             )
 
     return sparse
@@ -269,4 +279,6 @@ def to_sparse(dense):
         values = torch.tensor(0, dtype=dense.dtype, device=dense.device)
 
     # Construct sparse tensor
-    return torch.sparse_coo_tensor(indices.t(), values, dense.size(), dtype=dense.dtype, device=dense.device)
+    return torch.sparse_coo_tensor(
+        indices.t(), values, dense.size(), dtype=dense.dtype, device=dense.device, check_invariants=False
+    )

--- a/linear_operator/utils/sparse.py
+++ b/linear_operator/utils/sparse.py
@@ -210,7 +210,7 @@ def sparse_getitem(sparse, idxs):
                 raise RuntimeError("Unknown index type")
 
     return torch.sparse_coo_tensor(
-        indices, values, torch.Size(size), dtype=values.dtype, device=values.devicei, check_invariants=False
+        indices, values, torch.Size(size), dtype=values.dtype, device=values.device, check_invariants=False
     )
 
 


### PR DESCRIPTION
Fixes #131 by explicitly passing `check_invariants=False` to all calls of `torch.sparse_coo_tensor`, staying in line with the previous behavior but avoiding the `DeprecationWarning`.