### PR TITLE
## What's broken `MaskedLinearOperator.to(device=...)` crashes with `AttributeError` when called with a device but no dtype (e.g. `.to(device="cpu")`). The base `LinearOperator.to()` handles device-only moves fine; this subclass override (added to keep bool masks from being cast to float) regresses that path.

### DIFF
--- a/linear_operator/operators/masked_linear_operator.py
+++ b/linear_operator/operators/masked_linear_operator.py
@@ -138,7 +138,11 @@ class MaskedLinearOperator(LinearOperator):
         new_kwargs = {}
         for arg in self._args:
             if hasattr(arg, "to"):
-                if hasattr(arg, "dtype") and arg.dtype.is_floating_point == dtype.is_floating_point:
+                if (
+                    dtype is not None
+                    and hasattr(arg, "dtype")
+                    and arg.dtype.is_floating_point == dtype.is_floating_point
+                ):
                     new_args.append(arg.to(dtype=dtype, device=device))
                 else:
                     new_args.append(arg.to(device=device))

--- a/test/operators/test_masked_linear_operator.py
+++ b/test/operators/test_masked_linear_operator.py
@@ -38,6 +38,14 @@ class TestMaskedLinearOperator(LinearOperatorTestCase, unittest.TestCase):
         self.assertEqual(linear_op.col_mask.dtype, torch.bool)
         self.assertEqual(linear_op.row_mask.dtype, torch.bool)
 
+    def test_to_device(self):
+        # `.to(device=...)` with no dtype should not raise and should keep masks boolean.
+        linear_op = self.create_linear_op()
+        linear_op = linear_op.to(device=torch.device("cpu"))
+        self.assertEqual(linear_op.device.type, "cpu")
+        self.assertEqual(linear_op.col_mask.dtype, torch.bool)
+        self.assertEqual(linear_op.row_mask.dtype, torch.bool)
+
 
 class TestMaskedLinearOperatorBatch(LinearOperatorTestCase, unittest.TestCase):
     seed = 2023


### PR DESCRIPTION

## Why it happens
`_to_helper` returns `dtype=None` when only a device is supplied, but the override evaluates `arg.dtype.is_floating_point == dtype.is_floating_point` unconditionally, so `dtype.is_floating_point` raises when `dtype is None`.

## Fix
Guard with `dtype is not None`: when no dtype is requested, move every arg (including masks) by device only, preserving the bool dtype — matching base `to()`.

## Test
Added `test_to_device` (device-only move keeps masks boolean). Fails before (AttributeError), passes after; full masked-operator suite (167) green.